### PR TITLE
feat(cli): add issue and board data subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ go-jira supports four authentication modes:
 | MARKDOWN                        | Set to `true` to convert comment from Markdown to Jira format              |
 | DEBUG                           | Set to `true` to enable debug output                                       |
 | OUTPUT                          | Output format for the data subcommands: `json` (default) or `text`         |
-| EPIC_FIELD                      | Epic Link custom field ID for `create` (default `customfield_10101`)       |
-| SPRINT_FIELD                    | Sprint custom field ID for `create` (default `customfield_10100`)          |
+| EPIC_FIELD                      | Epic Link custom field ID used by `create`/`update`/`search` (default `customfield_10101`) |
+| SPRINT_FIELD                    | Sprint custom field ID used by `create`/`update`/`search` (default `customfield_10100`)    |
 | JIRA_OAUTH_CLIENT_ID            | OAuth client ID (overrides the embedded default)                           |
 | JIRA_OAUTH_CLIENT_SECRET        | OAuth client secret (overrides the embedded default)                       |
 | JIRA_OAUTH_REFRESH_TOKEN        | Injected refresh token; triggers CI `oauth-env` mode                       |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
       - [Log in with OAuth (local development)](#log-in-with-oauth-local-development)
       - [Show version](#show-version)
       - [Use custom environment file](#use-custom-environment-file)
+  - [Data subcommands](#data-subcommands)
   - [OAuth 2.0](#oauth-20)
 
 ## Motivation
@@ -85,6 +86,9 @@ go-jira supports four authentication modes:
 | COMMENT                         | Comment to add to the issue (optional)                                     |
 | MARKDOWN                        | Set to `true` to convert comment from Markdown to Jira format              |
 | DEBUG                           | Set to `true` to enable debug output                                       |
+| OUTPUT                          | Output format for the data subcommands: `json` (default) or `text`         |
+| EPIC_FIELD                      | Epic Link custom field ID for `create` (default `customfield_10101`)       |
+| SPRINT_FIELD                    | Sprint custom field ID for `create` (default `customfield_10100`)          |
 | JIRA_OAUTH_CLIENT_ID            | OAuth client ID (overrides the embedded default)                           |
 | JIRA_OAUTH_CLIENT_SECRET        | OAuth client secret (overrides the embedded default)                       |
 | JIRA_OAUTH_REFRESH_TOKEN        | Injected refresh token; triggers CI `oauth-env` mode                       |
@@ -139,6 +143,50 @@ go run ./cmd/go-jira --version
 ```bash
 go run ./cmd/go-jira run --env-file=custom.env
 ```
+
+## Data subcommands
+
+Beyond `run`, go-jira exposes a set of issue/board subcommands for scripting and
+automation. They share the same authentication (OAuth / Bearer / Basic), base
+URL, and `.env` resolution as every other command, and print machine-readable
+JSON to stdout by default. Pass `--output text` for a concise human-readable
+summary; errors go to stderr with a non-zero exit code.
+
+| Command   | Purpose                                  | Key flags                                                                            |
+| --------- | ---------------------------------------- | ------------------------------------------------------------------------------------ |
+| `search`  | Run a JQL query                          | `--jql` (required), `--fields`, `--limit`                                            |
+| `get`     | Fetch summary + status of one issue      | `--key` (required)                                                                   |
+| `create`  | Create a Task issue                      | `--project`, `--summary` (required), `--assignee`, `--description`, `--components`, `--labels`, `--epic`, `--sprint` |
+| `update`  | Partially update an issue's fields       | `--key` (required) + any of `--summary`, `--description`, `--assignee`, `--components`, `--labels`, `--epic`, `--sprint` |
+| `sprints` | List sprints for a board (Agile API)     | `--board-id` (required), `--state`, `--limit`                                        |
+| `boards`  | Discover boards for a project (Agile API)| `--project` (required), `--type`, `--limit`                                          |
+| `link`    | Link two issues                          | `--from`, `--to` (required), `--link-type`                                           |
+
+```bash
+export JIRA_BASE_URL="https://jira.example.com"
+export JIRA_TOKEN="your_personal_access_token"
+
+# Search (JSON to stdout)
+go run ./cmd/go-jira search --jql "project = GAIA AND status = Open" --limit 10
+
+# Human-readable summary
+go run ./cmd/go-jira get --key GAIA-123 --output text
+
+# Create a Task, attaching it to an epic and a sprint
+go run ./cmd/go-jira create --project GAIA --summary "Investigate flaky test" \
+  --epic GAIA-42 --sprint 55 --labels ci,flaky
+
+# Partial update — only the flags you pass are changed
+go run ./cmd/go-jira update --key GAIA-123 \
+  --summary "Reworded title" --assignee jdoe --labels triaged
+
+# Link two issues
+go run ./cmd/go-jira link --from GAIA-1 --to GAIA-2 --link-type Blocks
+```
+
+The epic-link and sprint custom field IDs vary per Jira instance. They default
+to `customfield_10101` / `customfield_10100`; override them with
+`--epic-field` / `--sprint-field` (or `EPIC_FIELD` / `SPRINT_FIELD`).
 
 ## OAuth 2.0
 

--- a/cmd/go-jira/apiclient.go
+++ b/cmd/go-jira/apiclient.go
@@ -23,7 +23,8 @@ func loadDataConfig(cmd *cobra.Command) (Config, error) {
 	}
 	if config.output != outputJSON && config.output != outputText {
 		return Config{}, fmt.Errorf(
-			"invalid --output %q: must be %q or %q", config.output, outputJSON, outputText,
+			"invalid output format %q (from --output or OUTPUT/INPUT_OUTPUT): must be %q or %q",
+			config.output, outputJSON, outputText,
 		)
 	}
 	return config, nil

--- a/cmd/go-jira/apiclient.go
+++ b/cmd/go-jira/apiclient.go
@@ -21,6 +21,11 @@ func loadDataConfig(cmd *cobra.Command) (Config, error) {
 	if err := requireBaseURL(config); err != nil {
 		return Config{}, err
 	}
+	if config.output != outputJSON && config.output != outputText {
+		return Config{}, fmt.Errorf(
+			"invalid --output %q: must be %q or %q", config.output, outputJSON, outputText,
+		)
+	}
 	return config, nil
 }
 

--- a/cmd/go-jira/apiclient.go
+++ b/cmd/go-jira/apiclient.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github/appleboy/go-jira/pkg/auth"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// loadDataConfig runs the common preamble for the data subcommands (search,
+// create, update, get, sprints, boards, link): load the env file, resolve the
+// config, and require a valid base URL. These commands have no --ref, so they
+// use requireBaseURL rather than the run-specific validateConfig.
+func loadDataConfig(cmd *cobra.Command) (Config, error) {
+	if err := loadEnvFromCmd(cmd); err != nil {
+		return Config{}, err
+	}
+	config := loadConfig(cmd)
+	if err := requireBaseURL(config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}
+
+// resolveJiraClient runs the auth + HTTP client + jira.Client preamble shared by
+// every Jira-talking subcommand (search, create, update, get, sprints, boards,
+// link). It mirrors the block in runWhoami: resolve the authenticator by the
+// usual priority, validate it, then build an authenticated jira.Client against
+// config.baseURL. Callers are expected to have already validated the base URL
+// (via requireBaseURL) and loaded the env file.
+func resolveJiraClient(ctx context.Context, config Config) (*jira.Client, error) {
+	authenticator, err := auth.Resolve(ctx, authConfigFromRun(config))
+	if err != nil {
+		return nil, fmt.Errorf("auth resolution: %w", err)
+	}
+	if err := authenticator.Validate(); err != nil {
+		return nil, fmt.Errorf("auth validation: %w", err)
+	}
+
+	httpClient := createHTTPClient(config, authenticator)
+	jiraClient, err := jira.NewClient(httpClient, config.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("error creating jira client: %w", err)
+	}
+	return jiraClient, nil
+}

--- a/cmd/go-jira/assignee.go
+++ b/cmd/go-jira/assignee.go
@@ -41,7 +41,7 @@ func processAssignee(
 			}
 			if resp.StatusCode != http.StatusNoContent {
 				err := fmt.Errorf("unexpected status: %s", resp.Status)
-				slog.Error("error updating assignee", "issue", iss.Key, "status", resp.Status)
+				slog.Error("error updating assignee", "issue", iss.Key, statusKey, resp.Status)
 				errChan <- err
 				return
 			}

--- a/cmd/go-jira/boards.go
+++ b/cmd/go-jira/boards.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// newBoardsCmd builds the `boards` subcommand: discover boards for a project
+// via the Agile API. Equivalent to the Python `boards` subcommand.
+func newBoardsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "boards",
+		Short:        "Discover boards for a project (Agile API)",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBoards(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	cmd.Flags().String(flagProject, "", "Project key, e.g. GAIA (required)")
+	cmd.Flags().String(flagBoardType, "", "Filter by board type: scrum|kanban")
+	cmd.Flags().Int(flagLimit, 10, "Maximum number of boards to return")
+	_ = cmd.MarkFlagRequired(flagProject)
+	return cmd
+}
+
+func runBoards(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	project, _ := cmd.Flags().GetString(flagProject)
+	boardType, _ := cmd.Flags().GetString(flagBoardType)
+	limit, _ := cmd.Flags().GetInt(flagLimit)
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	boards, resp, err := jiraClient.Board.GetAllBoardsWithContext(ctx, &jira.BoardListOptions{
+		ProjectKeyOrID: project,
+		BoardType:      boardType,
+		SearchOptions:  jira.SearchOptions{MaxResults: limit},
+	})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error listing boards for project %s: %w", project, err)
+	}
+
+	return emitResult(config, boards, func() {
+		for _, b := range boards.Values {
+			fmt.Fprintf(os.Stdout, "%d\t%s\t%s\n", b.ID, b.Type, b.Name)
+		}
+	})
+}

--- a/cmd/go-jira/comment.go
+++ b/cmd/go-jira/comment.go
@@ -50,7 +50,7 @@ func addComments(
 					"error adding comment",
 					"issue",
 					iss.Key,
-					"status",
+					statusKey,
 					resp.StatusCode,
 					"body",
 					string(body),

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -218,9 +218,8 @@ func resolveCallbackPort(cmd *cobra.Command) int {
 		if err == nil {
 			return port
 		}
-		// G706: v is the user's own env var echoed back to their stderr as a
+		// v is the user's own env var echoed back to their stderr as a
 		// structured field — diagnostics, not untrusted log injection.
-		//nolint:gosec // G706 false positive on a self-supplied env value
 		slog.Warn("ignoring invalid callback-port env var; falling back to flag/default",
 			"env", envOAuthCallbackPort, "value", v, "error", err)
 	}

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -31,8 +31,10 @@ type Config struct {
 
 	// Output format for the data subcommands: "json" (default) or "text".
 	output string
-	// Custom field IDs for the create subcommand. They vary per Jira instance,
-	// so they are configurable; defaults match the documented Server/DC layout.
+	// Custom field IDs used by the data subcommands that reference epic/sprint:
+	// create and update (to set the fields) and search (to append them to the
+	// default field selection). They vary per Jira instance, so they are
+	// configurable; defaults match the documented Server/DC layout.
 	epicField   string
 	sprintField string
 

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -29,6 +29,13 @@ type Config struct {
 	markdown     bool
 	debug        bool
 
+	// Output format for the data subcommands: "json" (default) or "text".
+	output string
+	// Custom field IDs for the create subcommand. They vary per Jira instance,
+	// so they are configurable; defaults match the documented Server/DC layout.
+	epicField   string
+	sprintField string
+
 	// OAuth
 	oauthClientID           string
 	oauthClientSecret       string
@@ -77,6 +84,22 @@ func loadConfig(cmd *cobra.Command) Config {
 		assignee:     getString(flagAssignee, "assignee"),
 		markdown:     getBool(flagMarkdown, "markdown"),
 		debug:        getBool(flagDebug, "debug"),
+		output:       getString(flagOutput, "output"),
+		epicField:    getString(flagEpicField, "epic_field"),
+		sprintField:  getString(flagSprintField, "sprint_field"),
+	}
+
+	// Output defaults to JSON (machine-readable, matching the Python CLI).
+	if cfg.output == "" {
+		cfg.output = outputJSON
+	}
+	// Custom field IDs default to the documented Jira Server/DC layout when
+	// neither the flag nor the env var sets them.
+	if cfg.epicField == "" {
+		cfg.epicField = defaultEpicField
+	}
+	if cfg.sprintField == "" {
+		cfg.sprintField = defaultSprintField
 	}
 
 	// Accept the JIRA_-prefixed env vars as aliases (lowest precedence: flag >

--- a/cmd/go-jira/create.go
+++ b/cmd/go-jira/create.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+	"github.com/trivago/tgo/tcontainer"
+)
+
+// newCreateCmd builds the `create` subcommand: create a Task issue. Equivalent
+// to the Python `create` subcommand, including epic-link and sprint custom
+// fields (configurable via --epic-field / --sprint-field).
+func newCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create",
+		Short:        "Create a Task issue",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCreate(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	addCustomFieldFlags(cmd)
+	addEditableIssueFlags(cmd)
+	cmd.Flags().String(flagProject, "", "Project key, e.g. GAIA (required)")
+	_ = cmd.MarkFlagRequired(flagProject)
+	_ = cmd.MarkFlagRequired(flagSummary)
+	return cmd
+}
+
+func runCreate(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	project, _ := cmd.Flags().GetString(flagProject)
+	summary, _ := cmd.Flags().GetString(flagSummary)
+	assignee, _ := cmd.Flags().GetString(flagAssignee)
+	description, _ := cmd.Flags().GetString(flagDescription)
+	components, _ := cmd.Flags().GetString(flagComponents)
+	labels, _ := cmd.Flags().GetString(flagLabels)
+	epic, _ := cmd.Flags().GetString(flagEpic)
+	sprint, _ := cmd.Flags().GetInt(flagSprint)
+	sprintSet := cmd.Flags().Changed(flagSprint)
+
+	fields := &jira.IssueFields{
+		Project:  jira.Project{Key: project},
+		Type:     jira.IssueType{Name: "Task"},
+		Summary:  summary,
+		Unknowns: tcontainer.NewMarshalMap(),
+	}
+	if description != "" {
+		fields.Description = description
+	}
+	if assignee != "" {
+		fields.Assignee = &jira.User{Name: assignee}
+	}
+	if components != "" {
+		fields.Components = splitComponents(components)
+	}
+	if labels != "" {
+		fields.Labels = splitCSV(labels)
+	}
+	if epic != "" {
+		fields.Unknowns[config.epicField] = epic
+	}
+	if sprintSet {
+		fields.Unknowns[config.sprintField] = sprint
+	}
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	created, resp, err := jiraClient.Issue.CreateWithContext(ctx, &jira.Issue{Fields: fields})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error creating issue: %w", err)
+	}
+
+	return emitResult(config, created, func() {
+		fmt.Fprintf(os.Stdout, "created %s\n", created.Key)
+	})
+}
+
+// splitCSV splits a comma-separated string into trimmed, non-empty values.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// splitComponents converts a comma-separated component-name list into the
+// library's component slice.
+func splitComponents(s string) []*jira.Component {
+	names := splitCSV(s)
+	out := make([]*jira.Component, 0, len(names))
+	for _, n := range names {
+		out = append(out, &jira.Component{Name: n})
+	}
+	return out
+}

--- a/cmd/go-jira/datacmd_test.go
+++ b/cmd/go-jira/datacmd_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns whatever
+// was written. emitResult writes the command result to os.Stdout, so this lets
+// the command tests assert on the rendered JSON/text.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// runDataCmd executes a freshly-built data subcommand against the test server,
+// returning its stdout and error. It injects the base URL, an explicit bearer
+// token (so auth resolves without touching the OS keyring), and --insecure (the
+// httptest server is plain http). JIRA_OAUTH_REFRESH_TOKEN is neutralized so a
+// developer's real env can't change the resolved auth mode.
+func runDataCmd(
+	t *testing.T,
+	cmd *cobra.Command,
+	serverURL string,
+	extraArgs ...string,
+) (string, error) {
+	t.Helper()
+	t.Setenv("JIRA_OAUTH_REFRESH_TOKEN", "")
+	args := append([]string{
+		"--env-file", "",
+		"--base-url", serverURL,
+		"--insecure",
+		"--token", "test-token",
+	}, extraArgs...)
+	cmd.SetArgs(args)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = cmd.Execute()
+	})
+	return out, runErr
+}
+
+func TestSplitCSV(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a , b ,c ", []string{"a", "b", "c"}},
+		{"a,,b", []string{"a", "b"}},
+		{"", []string{}},
+	}
+	for _, tt := range tests {
+		got := splitCSV(tt.in)
+		if len(got) != len(tt.want) {
+			t.Errorf("splitCSV(%q) = %v, want %v", tt.in, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("splitCSV(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+func TestSearchFields(t *testing.T) {
+	config := Config{epicField: "customfield_10101", sprintField: "customfield_10100"}
+
+	// Explicit --fields wins verbatim.
+	got := searchFields("summary, status ,labels", config)
+	want := []string{"summary", "status", "labels"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("searchFields explicit = %v, want %v", got, want)
+	}
+
+	// Default set appends the configured custom field IDs.
+	got = searchFields("", config)
+	joined := strings.Join(got, ",")
+	if !strings.Contains(joined, "customfield_10101") ||
+		!strings.Contains(joined, "customfield_10100") {
+		t.Errorf("searchFields default missing custom fields: %v", got)
+	}
+	if !strings.Contains(joined, "summary") || !strings.Contains(joined, "status") {
+		t.Errorf("searchFields default missing base fields: %v", got)
+	}
+}
+
+func TestSearchCmd(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			result := map[string]any{
+				"startAt":    0,
+				"maxResults": 20,
+				"total":      2,
+				"issues": []jira.Issue{
+					{Key: "GAIA-1", Fields: &jira.IssueFields{Summary: "first"}},
+					{Key: "GAIA-2", Fields: &jira.IssueFields{Summary: "second"}},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(result)
+		}),
+	)
+	defer server.Close()
+
+	// Happy path: JSON output contains both issues.
+	out, err := runDataCmd(t, newSearchCmd(), server.URL, "--jql", "project=GAIA")
+	if err != nil {
+		t.Fatalf("search returned error: %v", err)
+	}
+	if !strings.Contains(out, "GAIA-1") || !strings.Contains(out, "GAIA-2") {
+		t.Errorf("search output missing issues: %s", out)
+	}
+
+	// Text output: one tab-separated line per issue.
+	out, err = runDataCmd(t, newSearchCmd(), server.URL,
+		"--jql", "project=GAIA", "--output", "text")
+	if err != nil {
+		t.Fatalf("search text returned error: %v", err)
+	}
+	if lines := strings.Count(strings.TrimSpace(out), "\n"); lines != 1 {
+		t.Errorf("expected 2 text lines, got %d: %q", lines+1, out)
+	}
+}
+
+func TestSearchCmdMissingJQL(t *testing.T) {
+	// --jql is required; cobra should reject before any request.
+	_, err := runDataCmd(t, newSearchCmd(), "https://example.invalid")
+	if err == nil {
+		t.Fatal("expected error for missing --jql")
+	}
+}
+
+func TestSearchCmdServerError(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"errorMessages":["unauthorized"]}`))
+		}),
+	)
+	defer server.Close()
+
+	_, err := runDataCmd(t, newSearchCmd(), server.URL, "--jql", "project=GAIA")
+	if err == nil {
+		t.Fatal("expected error for HTTP 401")
+	}
+}
+
+func TestGetCmd(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := strings.TrimPrefix(r.URL.Path, "/rest/api/2/issue/")
+			_ = json.NewEncoder(w).Encode(jira.Issue{
+				Key: key,
+				Fields: &jira.IssueFields{
+					Summary: "the summary",
+					Status:  &jira.Status{Name: "Open"},
+				},
+			})
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newGetCmd(), server.URL, "--key", "GAIA-123")
+	if err != nil {
+		t.Fatalf("get returned error: %v", err)
+	}
+	if !strings.Contains(out, "GAIA-123") || !strings.Contains(out, "the summary") {
+		t.Errorf("get output missing fields: %s", out)
+	}
+}
+
+func TestCreateCmdCustomFields(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "1", "key": "GAIA-9"})
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newCreateCmd(), server.URL,
+		"--project", "GAIA", "--summary", "do the thing",
+		"--epic", "GAIA-42", "--sprint", "55",
+		"--components", "api,web", "--labels", "x,y")
+	if err != nil {
+		t.Fatalf("create returned error: %v", err)
+	}
+	if !strings.Contains(out, "GAIA-9") {
+		t.Errorf("create output missing key: %s", out)
+	}
+
+	fields, ok := gotBody["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("request body missing fields: %v", gotBody)
+	}
+	if fields["customfield_10101"] != "GAIA-42" {
+		t.Errorf("epic custom field = %v, want GAIA-42", fields["customfield_10101"])
+	}
+	// JSON numbers decode as float64.
+	if sprint, _ := fields["customfield_10100"].(float64); sprint != 55 {
+		t.Errorf("sprint custom field = %v, want 55", fields["customfield_10100"])
+	}
+	if comps, ok := fields["components"].([]any); !ok || len(comps) != 2 {
+		t.Errorf("components = %v, want 2 entries", fields["components"])
+	}
+}
+
+func TestCreateCmdCustomFieldOverride(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"key": "GAIA-9"})
+		}),
+	)
+	defer server.Close()
+
+	_, err := runDataCmd(t, newCreateCmd(), server.URL,
+		"--project", "GAIA", "--summary", "s",
+		"--epic", "GAIA-1", "--epic-field", "customfield_99999")
+	if err != nil {
+		t.Fatalf("create returned error: %v", err)
+	}
+	fields := gotBody["fields"].(map[string]any)
+	if fields["customfield_99999"] != "GAIA-1" {
+		t.Errorf("override epic field not used: %v", fields)
+	}
+	if _, exists := fields["customfield_10101"]; exists {
+		t.Errorf("default epic field should not be set when overridden: %v", fields)
+	}
+}
+
+func TestUpdateCmdNothingToUpdate(t *testing.T) {
+	_, err := runDataCmd(t, newUpdateCmd(), "https://example.invalid", "--key", "GAIA-1")
+	if err == nil || !strings.Contains(err.Error(), "nothing to update") {
+		t.Fatalf("expected 'nothing to update' error, got %v", err)
+	}
+}
+
+func TestUpdateCmd(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newUpdateCmd(), server.URL,
+		"--key", "GAIA-1", "--description", "new body")
+	if err != nil {
+		t.Fatalf("update returned error: %v", err)
+	}
+	if !strings.Contains(out, "updated") || !strings.Contains(out, "GAIA-1") {
+		t.Errorf("update output unexpected: %s", out)
+	}
+}
+
+func TestUpdateCmdAllFields(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer server.Close()
+
+	_, err := runDataCmd(t, newUpdateCmd(), server.URL,
+		"--key", "GAIA-1",
+		"--summary", "new summary",
+		"--assignee", "jdoe",
+		"--labels", "a,b",
+		"--components", "api,web",
+		"--epic", "GAIA-42",
+		"--sprint", "55")
+	if err != nil {
+		t.Fatalf("update returned error: %v", err)
+	}
+
+	fields, ok := gotBody["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("request body missing fields: %v", gotBody)
+	}
+	if fields["summary"] != "new summary" {
+		t.Errorf("summary = %v", fields["summary"])
+	}
+	if a, _ := fields["assignee"].(map[string]any); a == nil || a["name"] != "jdoe" {
+		t.Errorf("assignee = %v", fields["assignee"])
+	}
+	if labels, ok := fields["labels"].([]any); !ok || len(labels) != 2 {
+		t.Errorf("labels = %v", fields["labels"])
+	}
+	if comps, ok := fields["components"].([]any); !ok || len(comps) != 2 {
+		t.Errorf("components = %v", fields["components"])
+	}
+	if fields["customfield_10101"] != "GAIA-42" {
+		t.Errorf("epic field = %v", fields["customfield_10101"])
+	}
+	if sprint, _ := fields["customfield_10100"].(float64); sprint != 55 {
+		t.Errorf("sprint field = %v", fields["customfield_10100"])
+	}
+	// description was not passed, so it must not be in the partial update.
+	if _, exists := fields["description"]; exists {
+		t.Errorf("description should be absent in partial update: %v", fields)
+	}
+}
+
+func TestSprintsCmd(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(jira.SprintsList{
+				Values: []jira.Sprint{
+					{ID: 1, Name: "Sprint 1", State: "active"},
+				},
+			})
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newSprintsCmd(), server.URL, "--board-id", "10381")
+	if err != nil {
+		t.Fatalf("sprints returned error: %v", err)
+	}
+	if !strings.Contains(out, "Sprint 1") {
+		t.Errorf("sprints output missing sprint: %s", out)
+	}
+}
+
+func TestBoardsCmd(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(jira.BoardsList{
+				Values: []jira.Board{
+					{ID: 7, Name: "GAIA board", Type: "scrum"},
+				},
+			})
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newBoardsCmd(), server.URL, "--project", "GAIA")
+	if err != nil {
+		t.Fatalf("boards returned error: %v", err)
+	}
+	if !strings.Contains(out, "GAIA board") {
+		t.Errorf("boards output missing board: %s", out)
+	}
+}
+
+func TestLinkCmd(t *testing.T) {
+	var gotBody jira.IssueLink
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusCreated)
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newLinkCmd(), server.URL,
+		"--from", "GAIA-1", "--to", "GAIA-2", "--link-type", "Blocks")
+	if err != nil {
+		t.Fatalf("link returned error: %v", err)
+	}
+	if !strings.Contains(out, "linked") {
+		t.Errorf("link output unexpected: %s", out)
+	}
+	if gotBody.Type.Name != "Blocks" ||
+		gotBody.InwardIssue == nil || gotBody.InwardIssue.Key != "GAIA-1" ||
+		gotBody.OutwardIssue == nil || gotBody.OutwardIssue.Key != "GAIA-2" {
+		t.Errorf("link request body unexpected: %+v", gotBody)
+	}
+}

--- a/cmd/go-jira/datacmd_test.go
+++ b/cmd/go-jira/datacmd_test.go
@@ -25,6 +25,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	}
 	os.Stdout = w
 	defer func() { os.Stdout = orig }()
+	defer r.Close()
 
 	fn()
 
@@ -169,6 +170,14 @@ func TestSearchCmdServerError(t *testing.T) {
 	_, err := runDataCmd(t, newSearchCmd(), server.URL, "--jql", "project=GAIA")
 	if err == nil {
 		t.Fatal("expected error for HTTP 401")
+	}
+}
+
+func TestInvalidOutputRejected(t *testing.T) {
+	_, err := runDataCmd(t, newGetCmd(), "https://example.invalid",
+		"--key", "GAIA-1", "--output", "jsno")
+	if err == nil || !strings.Contains(err.Error(), "invalid --output") {
+		t.Fatalf("expected invalid --output error, got %v", err)
 	}
 }
 

--- a/cmd/go-jira/datacmd_test.go
+++ b/cmd/go-jira/datacmd_test.go
@@ -51,7 +51,17 @@ func runDataCmd(
 	extraArgs ...string,
 ) (string, error) {
 	t.Helper()
-	t.Setenv("JIRA_OAUTH_REFRESH_TOKEN", "")
+	// Neutralize every env var these commands resolve via util.GetGlobalValue
+	// (INPUT_<KEY> then <KEY>) plus the OAuth refresh token, so a developer's
+	// local environment can't change auth mode, output shape, or field IDs.
+	for _, k := range []string{
+		"JIRA_OAUTH_REFRESH_TOKEN",
+		"OUTPUT", "INPUT_OUTPUT",
+		"EPIC_FIELD", "INPUT_EPIC_FIELD",
+		"SPRINT_FIELD", "INPUT_SPRINT_FIELD",
+	} {
+		t.Setenv(k, "")
+	}
 	args := append([]string{
 		"--env-file", "",
 		"--base-url", serverURL,
@@ -176,8 +186,8 @@ func TestSearchCmdServerError(t *testing.T) {
 func TestInvalidOutputRejected(t *testing.T) {
 	_, err := runDataCmd(t, newGetCmd(), "https://example.invalid",
 		"--key", "GAIA-1", "--output", "jsno")
-	if err == nil || !strings.Contains(err.Error(), "invalid --output") {
-		t.Fatalf("expected invalid --output error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "invalid output format") {
+		t.Fatalf("expected invalid output format error, got %v", err)
 	}
 }
 

--- a/cmd/go-jira/get.go
+++ b/cmd/go-jira/get.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// newGetCmd builds the `get` subcommand: fetch summary and status for one
+// issue. Equivalent to the Python `get` subcommand.
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "get",
+		Short:        "Get the summary and status of a single issue",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runGet(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	cmd.Flags().String(flagKey, "", "Issue key, e.g. GAIA-123 (required)")
+	_ = cmd.MarkFlagRequired(flagKey)
+	return cmd
+}
+
+func runGet(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	key, _ := cmd.Flags().GetString(flagKey)
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	issue, resp, err := jiraClient.Issue.GetWithContext(ctx, key, &jira.GetQueryOptions{
+		Fields: "summary,status",
+	})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error getting issue %s: %w", key, err)
+	}
+
+	return emitResult(config, issue, func() {
+		status := ""
+		if issue.Fields != nil && issue.Fields.Status != nil {
+			status = issue.Fields.Status.Name
+		}
+		summary := ""
+		if issue.Fields != nil {
+			summary = issue.Fields.Summary
+		}
+		fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", issue.Key, status, summary)
+	})
+}

--- a/cmd/go-jira/link.go
+++ b/cmd/go-jira/link.go
@@ -62,7 +62,7 @@ func runLink(cmd *cobra.Command) error {
 		return fmt.Errorf("error linking %s -> %s: %w", from, to, err)
 	}
 
-	result := map[string]string{"status": "linked", "from": from, "to": to}
+	result := map[string]string{statusKey: "linked", "from": from, "to": to}
 	return emitResult(config, result, func() {
 		fmt.Fprintf(os.Stdout, "linked %s -> %s (%s)\n", from, to, linkType)
 	})

--- a/cmd/go-jira/link.go
+++ b/cmd/go-jira/link.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// newLinkCmd builds the `link` subcommand: create an issue link between two
+// tickets. Equivalent to the Python `link` subcommand.
+func newLinkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "link",
+		Short:        "Create an issue link between two tickets",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLink(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	cmd.Flags().String(flagFrom, "", "Inward issue key (required)")
+	cmd.Flags().String(flagTo, "", "Outward issue key (required)")
+	cmd.Flags().String(flagLinkType, "Relates", "Link type name")
+	_ = cmd.MarkFlagRequired(flagFrom)
+	_ = cmd.MarkFlagRequired(flagTo)
+	return cmd
+}
+
+func runLink(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	from, _ := cmd.Flags().GetString(flagFrom)
+	to, _ := cmd.Flags().GetString(flagTo)
+	linkType, _ := cmd.Flags().GetString(flagLinkType)
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	resp, err := jiraClient.Issue.AddLinkWithContext(ctx, &jira.IssueLink{
+		Type:         jira.IssueLinkType{Name: linkType},
+		InwardIssue:  &jira.Issue{Key: from},
+		OutwardIssue: &jira.Issue{Key: to},
+	})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error linking %s -> %s: %w", from, to, err)
+	}
+
+	result := map[string]string{"status": "linked", "from": from, "to": to}
+	return emitResult(config, result, func() {
+		fmt.Fprintf(os.Stdout, "linked %s -> %s (%s)\n", from, to, linkType)
+	})
+}

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -166,8 +166,10 @@ func addOutputFlag(cmd *cobra.Command) {
 		"Output format: json|text (env: OUTPUT / INPUT_OUTPUT)")
 }
 
-// addCustomFieldFlags registers the configurable custom field IDs used by
-// create. Field IDs vary per Jira instance, so they are overridable.
+// addCustomFieldFlags registers the configurable epic-link and sprint custom
+// field IDs. These are consumed by create and update (when setting the fields)
+// and by search (which appends them to the default field selection). Field IDs
+// vary per Jira instance, so they are overridable.
 func addCustomFieldFlags(cmd *cobra.Command) {
 	cmd.Flags().String(flagEpicField, defaultEpicField,
 		"Epic Link custom field ID (env: EPIC_FIELD / INPUT_EPIC_FIELD)")

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -111,6 +111,11 @@ const (
 	defaultSprintField = "customfield_10100"
 )
 
+// statusKey is the structured-log / JSON field name reused across status
+// messages and command results. Kept as a constant so the repeated literal
+// satisfies goconst.
+const statusKey = "status"
+
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
 		slog.Error("execution failed", "error", err)

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -41,6 +41,28 @@ const (
 	flagMarkdown     = "markdown"
 	flagDebug        = "debug"
 
+	// Data subcommand flags (search/create/update/get/sprints/boards/link).
+	flagOutput      = "output"
+	flagEpicField   = "epic-field"
+	flagSprintField = "sprint-field"
+	flagJQL         = "jql"
+	flagFields      = "fields"
+	flagLimit       = "limit"
+	flagProject     = "project"
+	flagSummary     = "summary"
+	flagDescription = "description"
+	flagComponents  = "components"
+	flagLabels      = "labels"
+	flagEpic        = "epic"
+	flagSprint      = "sprint"
+	flagKey         = "key"
+	flagBoardID     = "board-id"
+	flagState       = "state"
+	flagBoardType   = "type"
+	flagFrom        = "from"
+	flagTo          = "to"
+	flagLinkType    = "link-type"
+
 	// OAuth-related flags.
 	flagClientID     = "client-id"
 	flagClientSecret = "client-secret"
@@ -80,6 +102,13 @@ const (
 const (
 	defaultCallbackPort = 8765
 	defaultScope        = "WRITE"
+
+	// Default custom field IDs for the create subcommand. These match the
+	// documented Jira Server/DC layout (Epic Link / Sprint) and can be
+	// overridden per instance via --epic-field / --sprint-field or the
+	// EPIC_FIELD / SPRINT_FIELD env vars.
+	defaultEpicField   = "customfield_10101"
+	defaultSprintField = "customfield_10100"
 )
 
 func main() {
@@ -115,8 +144,53 @@ func newRootCmd() *cobra.Command {
 		newWhoamiCmd(),
 		newTokenCmd(),
 		newConfigCmd(),
+		newSearchCmd(),
+		newCreateCmd(),
+		newUpdateCmd(),
+		newGetCmd(),
+		newSprintsCmd(),
+		newBoardsCmd(),
+		newLinkCmd(),
 	)
 	return cmd
+}
+
+// addOutputFlag registers the shared --output flag for the data subcommands.
+func addOutputFlag(cmd *cobra.Command) {
+	cmd.Flags().String(flagOutput, outputJSON,
+		"Output format: json|text (env: OUTPUT / INPUT_OUTPUT)")
+}
+
+// addCustomFieldFlags registers the configurable custom field IDs used by
+// create. Field IDs vary per Jira instance, so they are overridable.
+func addCustomFieldFlags(cmd *cobra.Command) {
+	cmd.Flags().String(flagEpicField, defaultEpicField,
+		"Epic Link custom field ID (env: EPIC_FIELD / INPUT_EPIC_FIELD)")
+	cmd.Flags().String(flagSprintField, defaultSprintField,
+		"Sprint custom field ID (env: SPRINT_FIELD / INPUT_SPRINT_FIELD)")
+}
+
+// addAuthFlags registers the bearer/basic credential flags shared by the data
+// subcommands, mirroring run/whoami. OAuth and common flags are added
+// separately by each command.
+func addAuthFlags(cmd *cobra.Command) {
+	cmd.Flags().String(flagUsername, "", "Jira username (env: USERNAME / INPUT_USERNAME)")
+	cmd.Flags().String(flagPassword, "", "Jira password (prefer env: PASSWORD / INPUT_PASSWORD)")
+	cmd.Flags().String(flagToken, "", "Jira API token (prefer env: TOKEN / INPUT_TOKEN)")
+}
+
+// addEditableIssueFlags registers the issue field flags shared by create and
+// update: the fields a caller can set on an issue. create marks --summary
+// required and adds --project on top; update treats every flag as an optional
+// partial edit.
+func addEditableIssueFlags(cmd *cobra.Command) {
+	cmd.Flags().String(flagSummary, "", "Issue summary line")
+	cmd.Flags().String(flagAssignee, "", "Assignee login name")
+	cmd.Flags().String(flagDescription, "", "Issue description body")
+	cmd.Flags().String(flagComponents, "", "Comma-separated component names")
+	cmd.Flags().String(flagLabels, "", "Comma-separated labels")
+	cmd.Flags().String(flagEpic, "", "Epic key for the epic-link field, e.g. GAIA-42")
+	cmd.Flags().Int(flagSprint, 0, "Sprint ID for the sprint field")
 }
 
 // addCommonFlags registers flags shared by all subcommands that talk to Jira.

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -103,10 +103,10 @@ const (
 	defaultCallbackPort = 8765
 	defaultScope        = "WRITE"
 
-	// Default custom field IDs for the create subcommand. These match the
-	// documented Jira Server/DC layout (Epic Link / Sprint) and can be
-	// overridden per instance via --epic-field / --sprint-field or the
-	// EPIC_FIELD / SPRINT_FIELD env vars.
+	// Default custom field IDs used by the data subcommands that reference
+	// epic/sprint (create, update, and search). These match the documented Jira
+	// Server/DC layout (Epic Link / Sprint) and can be overridden per instance
+	// via --epic-field / --sprint-field or the EPIC_FIELD / SPRINT_FIELD env vars.
 	defaultEpicField   = "customfield_10101"
 	defaultSprintField = "customfield_10100"
 )

--- a/cmd/go-jira/output.go
+++ b/cmd/go-jira/output.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Output format values for the --output flag.
+const (
+	outputJSON = "json"
+	outputText = "text"
+)
+
+// emitResult renders a command result to stdout in the format selected by
+// config.output. The default (anything other than "text") prints v as indented
+// JSON, matching the Python CLI's machine-readable contract. When output is
+// "text", textFn is invoked to print a concise human-readable summary instead.
+//
+// Diagnostics and errors are written to stderr by callers (via slog / returned
+// errors); emitResult only ever writes the successful result to stdout.
+func emitResult(config Config, v any, textFn func()) error {
+	if config.output == outputText {
+		if textFn != nil {
+			textFn()
+		}
+		return nil
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("encoding result: %w", err)
+	}
+	return nil
+}

--- a/cmd/go-jira/search.go
+++ b/cmd/go-jira/search.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// defaultSearchBaseFields is the static part of the Python CLI's default field
+// selection. The configurable epic and sprint custom fields are appended at
+// runtime in searchFields so --epic-field / --sprint-field overrides apply.
+var defaultSearchBaseFields = []string{
+	"summary", "status", "assignee", "labels", "components",
+}
+
+// newSearchCmd builds the `search` subcommand: run a JQL query and print the
+// matching issues. Equivalent to the Python `search` subcommand.
+func newSearchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "search",
+		Short:        "Search Jira issues with a JQL query",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSearch(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	addCustomFieldFlags(cmd)
+	cmd.Flags().String(flagJQL, "", "JQL expression (required)")
+	cmd.Flags().String(flagFields, "",
+		"Comma-separated fields to return (default: summary,status,assignee,labels,components + epic/sprint fields)")
+	cmd.Flags().Int(flagLimit, 20, "Maximum number of results")
+	_ = cmd.MarkFlagRequired(flagJQL)
+	return cmd
+}
+
+func runSearch(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	jql, _ := cmd.Flags().GetString(flagJQL)
+	fieldsArg, _ := cmd.Flags().GetString(flagFields)
+	limit, _ := cmd.Flags().GetInt(flagLimit)
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	fields := searchFields(fieldsArg, config)
+	issues, resp, err := jiraClient.Issue.SearchWithContext(ctx, jql, &jira.SearchOptions{
+		Fields:     fields,
+		MaxResults: limit,
+	})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error searching issues: %w", err)
+	}
+
+	return emitResult(config, issues, func() {
+		for _, issue := range issues {
+			status := ""
+			if issue.Fields != nil && issue.Fields.Status != nil {
+				status = issue.Fields.Status.Name
+			}
+			summary := ""
+			if issue.Fields != nil {
+				summary = issue.Fields.Summary
+			}
+			fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", issue.Key, status, summary)
+		}
+	})
+}
+
+// searchFields returns the field list for the query. An explicit --fields value
+// wins; otherwise the default set is used with the configured epic/sprint
+// custom field IDs appended.
+func searchFields(fieldsArg string, config Config) []string {
+	if fieldsArg != "" {
+		parts := strings.Split(fieldsArg, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	fields := make([]string, 0, len(defaultSearchBaseFields)+2)
+	fields = append(fields, defaultSearchBaseFields...)
+	fields = append(fields, config.epicField, config.sprintField)
+	return fields
+}

--- a/cmd/go-jira/search.go
+++ b/cmd/go-jira/search.go
@@ -15,7 +15,7 @@ import (
 // selection. The configurable epic and sprint custom fields are appended at
 // runtime in searchFields so --epic-field / --sprint-field overrides apply.
 var defaultSearchBaseFields = []string{
-	"summary", "status", "assignee", "labels", "components",
+	"summary", statusKey, flagAssignee, "labels", "components",
 }
 
 // newSearchCmd builds the `search` subcommand: run a JQL query and print the

--- a/cmd/go-jira/search.go
+++ b/cmd/go-jira/search.go
@@ -11,11 +11,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// defaultSearchBaseFields is the static part of the Python CLI's default field
-// selection. The configurable epic and sprint custom fields are appended at
-// runtime in searchFields so --epic-field / --sprint-field overrides apply.
+// defaultSearchBaseFields is the static part of the default field selection.
+// These are Jira REST field names, kept as literals and intentionally
+// independent of the CLI flag / log-key constants that happen to share the same
+// text — renaming a flag must not silently change the fields requested from
+// Jira. The configurable epic and sprint custom fields are appended at runtime
+// in searchFields so --epic-field / --sprint-field overrides apply.
 var defaultSearchBaseFields = []string{
-	"summary", statusKey, flagAssignee, "labels", "components",
+	"summary",
+	"status",   //nolint:goconst // Jira REST field name, not the statusKey log constant
+	"assignee", //nolint:goconst // Jira REST field name, not the flagAssignee constant
+	"labels",
+	"components",
 }
 
 // newSearchCmd builds the `search` subcommand: run a JQL query and print the

--- a/cmd/go-jira/sprints.go
+++ b/cmd/go-jira/sprints.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/spf13/cobra"
+)
+
+// newSprintsCmd builds the `sprints` subcommand: list sprints for a board via
+// the Agile API. Equivalent to the Python `sprints` subcommand.
+func newSprintsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "sprints",
+		Short:        "List sprints for a board (Agile API)",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSprints(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	cmd.Flags().Int(flagBoardID, 0, "Board ID, e.g. 10381 (required)")
+	cmd.Flags().String(flagState, "active", "Sprint state filter: active|closed|future")
+	cmd.Flags().Int(flagLimit, 10, "Maximum number of sprints to return")
+	_ = cmd.MarkFlagRequired(flagBoardID)
+	return cmd
+}
+
+func runSprints(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	boardID, _ := cmd.Flags().GetInt(flagBoardID)
+	state, _ := cmd.Flags().GetString(flagState)
+	limit, _ := cmd.Flags().GetInt(flagLimit)
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	sprints, resp, err := jiraClient.Board.GetAllSprintsWithOptionsWithContext(
+		ctx, boardID, &jira.GetAllSprintsOptions{
+			State:         state,
+			SearchOptions: jira.SearchOptions{MaxResults: limit},
+		})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error listing sprints for board %d: %w", boardID, err)
+	}
+
+	return emitResult(config, sprints, func() {
+		for _, sp := range sprints.Values {
+			fmt.Fprintf(os.Stdout, "%d\t%s\t%s\n", sp.ID, sp.State, sp.Name)
+		}
+	})
+}

--- a/cmd/go-jira/token.go
+++ b/cmd/go-jira/token.go
@@ -41,6 +41,7 @@ func newTokenPrintCmd() *cobra.Command {
 
 func newTokenStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
+		//nolint:goconst // cobra subcommand name, independent of the statusKey field constant
 		Use:          "status",
 		Short:        "Show token mode, time remaining, scopes, and storage backend",
 		SilenceUsage: true,

--- a/cmd/go-jira/transition.go
+++ b/cmd/go-jira/transition.go
@@ -61,7 +61,7 @@ func processTransitions(
 				}
 				if resp.StatusCode != http.StatusNoContent {
 					err := fmt.Errorf("unexpected status: %s", resp.Status)
-					slog.Error("error moving issue", "issue", iss.Key, "status", resp.Status)
+					slog.Error("error moving issue", "issue", iss.Key, statusKey, resp.Status)
 					errChan <- err
 					return
 				}

--- a/cmd/go-jira/update.go
+++ b/cmd/go-jira/update.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newUpdateCmd builds the `update` subcommand: apply a partial edit to an
+// existing issue. It accepts the same editable fields as create (summary,
+// assignee, description, components, labels, epic, sprint); only the flags the
+// caller explicitly sets are sent, so unspecified fields are left untouched.
+func newUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "update",
+		Short:        "Update fields of an existing issue",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runUpdate(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	addCustomFieldFlags(cmd)
+	addEditableIssueFlags(cmd)
+	cmd.Flags().String(flagKey, "", "Issue key, e.g. GAIA-123 (required)")
+	_ = cmd.MarkFlagRequired(flagKey)
+	return cmd
+}
+
+func runUpdate(cmd *cobra.Command) error {
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	key, _ := cmd.Flags().GetString(flagKey)
+
+	fields := editableFieldsMap(cmd, config)
+	if len(fields) == 0 {
+		return errors.New(
+			"nothing to update — supply at least one of " +
+				"--summary/--description/--assignee/--components/--labels/--epic/--sprint",
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(cmdContext(cmd), time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	resp, err := jiraClient.Issue.UpdateIssueWithContext(ctx, key, map[string]any{"fields": fields})
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error updating issue %s: %w", key, err)
+	}
+
+	result := map[string]string{"status": "updated", "key": key}
+	return emitResult(config, result, func() {
+		fmt.Fprintf(os.Stdout, "updated %s\n", key)
+	})
+}
+
+// editableFieldsMap builds a Jira REST "fields" payload from the editable issue
+// flags (see addEditableIssueFlags), including only the flags the caller set.
+// Values use the raw JSON shapes the REST API expects so the same builder works
+// for partial updates and for any future map-based create path. The epic and
+// sprint custom field IDs come from config (configurable per instance).
+func editableFieldsMap(cmd *cobra.Command, config Config) map[string]any {
+	fields := map[string]any{}
+	if cmd.Flags().Changed(flagSummary) {
+		v, _ := cmd.Flags().GetString(flagSummary)
+		fields["summary"] = v
+	}
+	if cmd.Flags().Changed(flagDescription) {
+		v, _ := cmd.Flags().GetString(flagDescription)
+		fields["description"] = v
+	}
+	if cmd.Flags().Changed(flagAssignee) {
+		v, _ := cmd.Flags().GetString(flagAssignee)
+		fields["assignee"] = map[string]string{"name": v}
+	}
+	if cmd.Flags().Changed(flagComponents) {
+		v, _ := cmd.Flags().GetString(flagComponents)
+		fields["components"] = componentRefs(v)
+	}
+	if cmd.Flags().Changed(flagLabels) {
+		v, _ := cmd.Flags().GetString(flagLabels)
+		fields["labels"] = splitCSV(v)
+	}
+	if cmd.Flags().Changed(flagEpic) {
+		v, _ := cmd.Flags().GetString(flagEpic)
+		fields[config.epicField] = v
+	}
+	if cmd.Flags().Changed(flagSprint) {
+		v, _ := cmd.Flags().GetInt(flagSprint)
+		fields[config.sprintField] = v
+	}
+	return fields
+}
+
+// componentRefs converts a comma-separated component-name list into the
+// {"name": ...} reference objects the REST API expects.
+func componentRefs(s string) []map[string]string {
+	names := splitCSV(s)
+	out := make([]map[string]string, 0, len(names))
+	for _, n := range names {
+		out = append(out, map[string]string{"name": n})
+	}
+	return out
+}

--- a/cmd/go-jira/update.go
+++ b/cmd/go-jira/update.go
@@ -65,7 +65,7 @@ func runUpdate(cmd *cobra.Command) error {
 		return fmt.Errorf("error updating issue %s: %w", key, err)
 	}
 
-	result := map[string]string{"status": "updated", "key": key}
+	result := map[string]string{statusKey: "updated", flagKey: key}
 	return emitResult(config, result, func() {
 		fmt.Fprintf(os.Stdout, "updated %s\n", key)
 	})

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/spf13/cobra v1.10.2
+	github.com/trivago/tgo v1.0.7
 	github.com/yassinebenaid/godump v0.11.1
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0
@@ -22,7 +23,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	github.com/trivago/tgo v1.0.7 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )


### PR DESCRIPTION
## Summary
Adds seven issue/board data subcommands to the go-jira CLI — `search`, `get`, `create`, `update`, `sprints`, `boards`, `link` — porting the capabilities of a stand-alone Python Jira script into the Go CLI so they share the existing auth (OAuth/Bearer/Basic), config resolution, TLS handling, and `.env` loading. Results print as JSON to stdout by default (machine-readable for automation) with a `--output text` summary option.

## AI Authorship
- [ ] No AI was used in this PR
- [x] AI was used. Details:
  - **Tool / model**: Claude Opus 4.7 (Claude Code), interactive session
  - **AI-authored files**: **all files in this PR** (every new command file, the shared helpers, the test file, and the README/config/main.go edits)
  - **Human line-by-line reviewed**: **none yet** — the author has not line-by-line reviewed this code. ⚠️ Reviewers should treat the entire diff as needing careful review, not spot-checks.

## Change classification
- [x] Leaf node (local impact) — these are additive, self-contained subcommands; nothing else in the codebase depends on them, and the existing `run`/auth paths are untouched.
- [ ] Core code
  - **Caveat**: `create`/`update`/`link` perform **writes to a live Jira instance** (external side effects). See the security section.

## Plan reference
Goal: provide first-class CLI subcommands for Jira issue/board operations (JQL search, issue get/create/update, board/sprint discovery, issue linking), reusing all existing auth/config plumbing rather than a separate script.

Decisions made during planning:
- Default JSON output; `--output text` for summaries.
- `epics` subcommand intentionally **skipped** (library has no epic-list method).
- Epic-link / sprint custom field IDs configurable per instance (`--epic-field` / `--sprint-field`, default `customfield_10101` / `customfield_10100`).

## Verification
- [x] Unit tests — pure helpers (`splitCSV`, `searchFields`, `editableFieldsMap`)
- [x] Command-level tests — all 7 commands driven through cobra against `httptest` servers (14 test functions total)
- [x] At least 3 e2e-style tests (happy path + error cases):
  - Happy: `search` returns 2 issues (JSON + text shapes)
  - Error: `search` missing required `--jql` rejected by cobra
  - Error: HTTP 401 from server surfaces a non-zero exit
  - Plus: `update` "nothing to update" guard; `create`/`update` request-body assertions for custom fields + types; `--epic-field` override
- [ ] Stress / soak test: N/A (synchronous, short-lived requests)
- **Manual verification (live instance)**: `create`, `get`, `search`, `update` (summary/labels/assignee), `boards`, `link` all verified end-to-end and read-back confirmed. `sprints` executes cleanly (target board had no sprints). `create --epic/--sprint` were **not** live-verified (no epic/sprint available on the test board and the instance's real field IDs were unconfirmed) — they are covered by request-body unit assertions only.

## Verifiability check
- [x] Inputs (flags/env) and outputs (JSON/text) documented in README
- [x] Reviewer can judge correctness from flag→REST mapping + tests
- [x] Errors return non-zero exit with the server error body

## Security check (PR touches an external write interface)
- [x] No secrets in code (live `.env` and generated `*.pem` excluded from the commit)
- [x] External inputs: flags map to typed Jira REST fields; JQL is sent as-is to the Jira API (server-side validated — no local injection surface)
- [x] Auth reuses the existing resolver; no new credential handling added
- [x] Errors propagate the Jira status/body without leaking local internals
- [ ] Rate limits: N/A (single-request commands)

## Risk & rollback
- **Risk**: (1) Entire diff is AI-authored and not yet human-reviewed. (2) `create`/`update` write to real Jira — a wrong custom-field ID could write to the wrong field (mitigated by configurable `--epic-field`/`--sprint-field` + documented defaults). (3) Diff is ~1.3k lines (above the 500-line guideline), though it's mostly new, isolated files + 403 lines of tests.
- **Rollback**: fully additive (new files + a few additive lines in `main.go`/`config.go`/`go.mod`/`README.md`); revert the single commit to remove.

## Reviewer guide
- **Read carefully**:
  - `cmd/go-jira/create.go` & `cmd/go-jira/update.go` — field building, custom field handling, partial-update semantics (only `Changed` flags are sent)
  - `cmd/go-jira/apiclient.go` — shared auth/client preamble
  - `cmd/go-jira/main.go` & `config.go` — flag/config wiring, defaults
- **Spot-check OK** (thin wrappers, well covered by tests):
  - `get.go`, `search.go`, `sprints.go`, `boards.go`, `link.go`, `output.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
