### PR TITLE
feat(oauth): add --callback-https with in-memory loopback cert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ JIRA_TOKEN=
 # both; the redirect URI then becomes https://127.0.0.1:<port>/callback.
 # JIRA_OAUTH_CALLBACK_CERT=./localhost+1.pem
 # JIRA_OAUTH_CALLBACK_KEY=./localhost+1-key.pem
+# Or, for zero setup (no cert files, e.g. a binary shared across a team), serve
+# the HTTPS callback with a self-signed cert generated in memory at login time.
+# The browser shows a one-time "proceed to 127.0.0.1" warning to accept.
+# JIRA_OAUTH_CALLBACK_HTTPS=true
 
 # Mode 4: OAuth, CI/CD — inject a refresh token. Jira DC rotates the refresh
 # token on every refresh, so write the new one back to your secret store via

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ go-jira supports four authentication modes:
 | JIRA_OAUTH_CALLBACK_PORT        | Local OAuth callback port (default `8765`)                                 |
 | JIRA_OAUTH_CALLBACK_CERT        | TLS cert file for an HTTPS login callback (with `JIRA_OAUTH_CALLBACK_KEY`) |
 | JIRA_OAUTH_CALLBACK_KEY         | TLS key file for an HTTPS login callback (with `JIRA_OAUTH_CALLBACK_CERT`) |
+| JIRA_OAUTH_CALLBACK_HTTPS       | `true` to serve the HTTPS callback with an auto-generated in-memory cert (no cert files; browser shows a one-time warning) |
 | JIRA_MASTER_PASSWORD            | Master password for the encrypted file token store (when no keyring)       |
 
 ### Usage

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	callbackPort            int
 	callbackCert            string
 	callbackKey             string
+	callbackHTTPS           bool
 }
 
 // loadConfig resolves configuration from CLI flags (when explicitly set)
@@ -148,6 +149,7 @@ func loadConfig(cmd *cobra.Command) Config {
 	cfg.callbackKey = resolveWithEnv(
 		envOAuthCallbackKey, flagStringValue(cmd, flagCallbackKey), "",
 	)
+	cfg.callbackHTTPS = resolveCallbackHTTPS(cmd)
 
 	warnOnSecretFlags(cmd)
 	return cfg
@@ -231,6 +233,27 @@ func resolveCallbackPort(cmd *cobra.Command) int {
 	return defaultCallbackPort
 }
 
+// flagBoolValue returns a bool flag's value when the command defines it and the
+// user changed it, otherwise false.
+func flagBoolValue(cmd *cobra.Command, name string) bool {
+	if cmd == nil || cmd.Flags().Lookup(name) == nil || !cmd.Flags().Changed(name) {
+		return false
+	}
+	v, _ := cmd.Flags().GetBool(name)
+	return v
+}
+
+// resolveCallbackHTTPS applies env > flag precedence for the "generate an
+// in-memory https callback cert" toggle, matching the callback cert/key
+// resolution. A set env var (any value) decides via util.ToBool; otherwise the
+// flag is consulted.
+func resolveCallbackHTTPS(cmd *cobra.Command) bool {
+	if v := os.Getenv(envOAuthCallbackHTTPS); v != "" {
+		return util.ToBool(v)
+	}
+	return flagBoolValue(cmd, flagCallbackHTTPS)
+}
+
 // resolveWithEnv applies the env > flag > embedded-default precedence used for
 // the OAuth client ID and secret.
 func resolveWithEnv(envKey, flagVal, embedded string) string {
@@ -244,11 +267,12 @@ func resolveWithEnv(envKey, flagVal, embedded string) string {
 }
 
 // redirectURI builds the loopback callback URL for the configured port. It uses
-// the https scheme when a callback TLS cert+key pair is configured (required by
-// Jira DC, which rejects an http redirect URI), and http otherwise.
+// the https scheme when an https callback is requested — either via a supplied
+// TLS cert+key pair or the auto-generated cert (--callback-https), both of which
+// Jira DC needs since it rejects an http redirect URI — and http otherwise.
 func (c Config) redirectURI() string {
 	scheme := "http"
-	if c.callbackCert != "" && c.callbackKey != "" {
+	if c.callbackHTTPS || (c.callbackCert != "" && c.callbackKey != "") {
 		scheme = "https"
 	}
 	return fmt.Sprintf("%s://127.0.0.1:%d/callback", scheme, c.callbackPort)

--- a/cmd/go-jira/config_test.go
+++ b/cmd/go-jira/config_test.go
@@ -72,11 +72,48 @@ func TestRedirectURI(t *testing.T) {
 			Config{callbackPort: 8765, callbackCert: "c.pem"},
 			"http://127.0.0.1:8765/callback",
 		},
+		{
+			"https when callbackHTTPS set (generated cert)",
+			Config{callbackPort: 8765, callbackHTTPS: true},
+			"https://127.0.0.1:8765/callback",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.cfg.redirectURI(); got != tt.want {
 				t.Errorf("redirectURI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCallbackHTTPS(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string // "" means unset
+		args []string
+		want bool
+	}{
+		{"default off", "", nil, false},
+		{"flag only", "", []string{"--callback-https"}, true},
+		{"env only", "true", nil, true},
+		{"env 1 is truthy", "1", nil, true},
+		{"env false beats unset flag", "false", nil, false},
+		{"env true beats unset flag", "true", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env == "" {
+				os.Unsetenv(envOAuthCallbackHTTPS)
+			} else {
+				t.Setenv(envOAuthCallbackHTTPS, tt.env)
+			}
+			cmd := newLoginCmd()
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			if got := resolveCallbackHTTPS(cmd); got != tt.want {
+				t.Errorf("resolveCallbackHTTPS() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/go-jira/config_test.go
+++ b/cmd/go-jira/config_test.go
@@ -103,11 +103,10 @@ func TestResolveCallbackHTTPS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.env == "" {
-				os.Unsetenv(envOAuthCallbackHTTPS)
-			} else {
-				t.Setenv(envOAuthCallbackHTTPS, tt.env)
-			}
+			// t.Setenv("") behaves as unset for the code under test and, unlike
+			// os.Unsetenv, restores the prior value after the test so state never
+			// leaks into other tests.
+			t.Setenv(envOAuthCallbackHTTPS, tt.env)
 			cmd := newLoginCmd()
 			if err := cmd.ParseFlags(tt.args); err != nil {
 				t.Fatalf("ParseFlags: %v", err)

--- a/cmd/go-jira/config_test.go
+++ b/cmd/go-jira/config_test.go
@@ -100,6 +100,8 @@ func TestResolveCallbackHTTPS(t *testing.T) {
 		{"env 1 is truthy", "1", nil, true},
 		{"env false beats unset flag", "false", nil, false},
 		{"env true beats unset flag", "true", nil, true},
+		{"env false beats set flag", "false", []string{"--callback-https"}, false},
+		{"env true with set flag", "true", []string{"--callback-https"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -64,14 +64,15 @@ const (
 	flagLinkType    = "link-type"
 
 	// OAuth-related flags.
-	flagClientID     = "client-id"
-	flagClientSecret = "client-secret"
-	flagCallbackPort = "callback-port"
-	flagCallbackCert = "callback-cert"
-	flagCallbackKey  = "callback-key"
-	flagScope        = "scope"
-	flagTimeout      = "timeout"
-	flagConfirm      = "confirm"
+	flagClientID      = "client-id"
+	flagClientSecret  = "client-secret"
+	flagCallbackPort  = "callback-port"
+	flagCallbackCert  = "callback-cert"
+	flagCallbackKey   = "callback-key"
+	flagCallbackHTTPS = "callback-https"
+	flagScope         = "scope"
+	flagTimeout       = "timeout"
+	flagConfirm       = "confirm"
 )
 
 // OAuth environment variables. Unlike the action config (which uses the
@@ -85,6 +86,7 @@ const (
 	envOAuthCallbackPort       = "JIRA_OAUTH_CALLBACK_PORT"
 	envOAuthCallbackCert       = "JIRA_OAUTH_CALLBACK_CERT"
 	envOAuthCallbackKey        = "JIRA_OAUTH_CALLBACK_KEY"
+	envOAuthCallbackHTTPS      = "JIRA_OAUTH_CALLBACK_HTTPS"
 	envMasterPassword          = "JIRA_MASTER_PASSWORD"
 
 	// JIRA_-prefixed aliases for the core auth/config fields, matching the env
@@ -222,6 +224,10 @@ func addOAuthFlags(cmd *cobra.Command) {
 	cmd.Flags().String(flagCallbackKey, "",
 		"TLS key file for an https callback server (env: "+envOAuthCallbackKey+
 			"); requires --"+flagCallbackCert)
+	cmd.Flags().Bool(flagCallbackHTTPS, false,
+		"Serve the https callback with an auto-generated in-memory loopback cert, so "+
+			"no cert/key files are needed (env: "+envOAuthCallbackHTTPS+
+			"); the browser shows a one-time security warning to accept")
 	cmd.Flags().String(flagScope, defaultScope, "OAuth scope to request")
 }
 

--- a/cmd/go-jira/oauthcli.go
+++ b/cmd/go-jira/oauthcli.go
@@ -138,14 +138,15 @@ func resolveStore() (storage.Store, error) {
 // config, applying the insecure HTTP client when requested.
 func oauthConfigFromConfig(config Config) *oauth.Config {
 	return &oauth.Config{
-		BaseURL:      config.baseURL,
-		ClientID:     config.oauthClientID,
-		ClientSecret: config.oauthClientSecret,
-		RedirectURI:  config.redirectURI(),
-		Scopes:       []string{config.scope},
-		TLSCertFile:  config.callbackCert,
-		TLSKeyFile:   config.callbackKey,
-		HTTPClient:   oauthHTTPClient(config),
+		BaseURL:         config.baseURL,
+		ClientID:        config.oauthClientID,
+		ClientSecret:    config.oauthClientSecret,
+		RedirectURI:     config.redirectURI(),
+		Scopes:          []string{config.scope},
+		TLSCertFile:     config.callbackCert,
+		TLSKeyFile:      config.callbackKey,
+		GenerateTLSCert: config.callbackHTTPS,
+		HTTPClient:      oauthHTTPClient(config),
 	}
 }
 

--- a/docs/oauth-usage.md
+++ b/docs/oauth-usage.md
@@ -42,6 +42,30 @@ installs a local CA so the browser redirect is trusted without a warning. The
 equivalent env vars are `JIRA_OAUTH_CALLBACK_CERT` / `JIRA_OAUTH_CALLBACK_KEY`.
 Both must be set together, or neither.
 
+#### Zero-setup HTTPS callback (`--callback-https`)
+
+If you just want an https callback to work without provisioning any cert files —
+useful when **sharing one binary across a team** — pass `--callback-https` (or
+set `JIRA_OAUTH_CALLBACK_HTTPS=true`):
+
+```bash
+go-jira login --callback-https
+```
+
+This mints a self-signed certificate for `127.0.0.1` **in memory** at login
+time. No `mkcert`, no cert/key files, and nothing secret is baked into the
+binary. The redirect URI still becomes `https://127.0.0.1:<port>/callback`, so
+register that exact value in Jira.
+
+Trade-off: because the cert is self-signed (not signed by a CA your machine
+already trusts), the browser shows a one-time security warning. On `127.0.0.1`
+you can click **“Proceed to 127.0.0.1 (unsafe)”** to continue; the login then
+completes normally. If you want to avoid the warning entirely, use the
+`mkcert`-based `--callback-cert` / `--callback-key` approach above instead.
+
+When both `--callback-https` and an explicit `--callback-cert` / `--callback-key`
+pair are given, the supplied files win.
+
 You then have a **client ID** and **client secret**. These can be:
 
 1. embedded into the binary at build time (see [migration & build](#building-with-an-embedded-client)), or

--- a/pkg/oauth/callback.go
+++ b/pkg/oauth/callback.go
@@ -24,17 +24,40 @@ type callbackResult struct {
 	Err   error
 }
 
+// resolveCallbackCert returns the certificate the callback server should serve,
+// or nil for plain HTTP. An explicit cert/key file pair takes precedence over
+// GenerateTLSCert. Loading/generation happens here, before the listener starts,
+// so a bad or missing cert fails Login synchronously instead of being swallowed
+// by the Serve goroutine and surfacing only as a hung redirect.
+func (c *Config) resolveCallbackCert() (*tls.Certificate, error) {
+	switch {
+	case c.TLSCertFile != "" && c.TLSKeyFile != "":
+		cert, err := tls.LoadX509KeyPair(c.TLSCertFile, c.TLSKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("oauth: load TLS key pair: %w", err)
+		}
+		return &cert, nil
+	case c.GenerateTLSCert:
+		cert, err := GenerateLoopbackCert()
+		if err != nil {
+			return nil, err
+		}
+		return &cert, nil
+	default:
+		return nil, nil
+	}
+}
+
 // startCallbackServer starts a server on 127.0.0.1:port that listens for the
 // OAuth redirect. It returns a channel that receives exactly one result, and a
 // shutdown function the caller MUST call (typically via defer).
 //
-// When certFile and keyFile are both non-empty the server serves HTTPS using
-// that key pair (for Jira DC, which requires an https redirect URI); otherwise
-// it serves plain HTTP.
+// When cert is non-nil the server serves HTTPS with it (for Jira DC, which
+// requires an https redirect URI); otherwise it serves plain HTTP.
 func startCallbackServer(
 	port int,
 	expectedState string,
-	certFile, keyFile string,
+	cert *tls.Certificate,
 ) (<-chan callbackResult, func(context.Context) error, error) {
 	resultCh := make(chan callbackResult, 1)
 
@@ -84,18 +107,9 @@ func startCallbackServer(
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	if certFile != "" || keyFile != "" {
-		// Load the key pair before serving so a bad/missing cert fails Login
-		// synchronously here, instead of being swallowed by the Serve goroutine
-		// and surfacing only as a connection-refused redirect that hangs until
-		// timeout. Config.Validate already rejects a half-set pair.
-		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-		if err != nil {
-			_ = ln.Close()
-			return nil, nil, fmt.Errorf("oauth: load TLS key pair: %w", err)
-		}
+	if cert != nil {
 		srv.TLSConfig = &tls.Config{
-			Certificates: []tls.Certificate{cert},
+			Certificates: []tls.Certificate{*cert},
 			MinVersion:   tls.VersionTLS12,
 		}
 		// Certs are already loaded into TLSConfig, so the file args are empty.

--- a/pkg/oauth/callback.go
+++ b/pkg/oauth/callback.go
@@ -17,6 +17,10 @@ import (
 // mismatch fails fast instead of hanging until timeout.
 const callbackPath = "/callback"
 
+// loopbackHost is the IPv4 loopback address the callback server binds and the
+// redirect URI must use.
+const loopbackHost = "127.0.0.1"
+
 // callbackResult carries the outcome of the OAuth redirect back to the caller.
 type callbackResult struct {
 	Code  string
@@ -95,7 +99,7 @@ func startCallbackServer(
 		send(callbackResult{Code: code, State: q.Get("state")})
 	})
 
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := fmt.Sprintf("%s:%d", loopbackHost, port)
 	var lc net.ListenConfig
 	ln, err := lc.Listen(context.Background(), "tcp", addr)
 	if err != nil {

--- a/pkg/oauth/callback.go
+++ b/pkg/oauth/callback.go
@@ -112,7 +112,8 @@ func startCallbackServer(
 			Certificates: []tls.Certificate{*cert},
 			MinVersion:   tls.VersionTLS12,
 		}
-		// Certs are already loaded into TLSConfig, so the file args are empty.
+		// The cert is already loaded into TLSConfig, so ServeTLS needs no
+		// cert/key file paths.
 		go func() { _ = srv.ServeTLS(ln, "", "") }()
 		return resultCh, srv.Shutdown, nil
 	}

--- a/pkg/oauth/callback_test.go
+++ b/pkg/oauth/callback_test.go
@@ -57,7 +57,7 @@ func TestCallbackServer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			port := freePort(t)
-			resultCh, shutdown, err := startCallbackServer(port, "expected", "", "")
+			resultCh, shutdown, err := startCallbackServer(port, "expected", nil)
 			if err != nil {
 				t.Fatalf("startCallbackServer: %v", err)
 			}

--- a/pkg/oauth/cert.go
+++ b/pkg/oauth/cert.go
@@ -16,9 +16,14 @@ import (
 // loopbackCertTTL bounds the validity of a generated callback certificate. A
 // fresh cert is minted on every login, so the window only needs to comfortably
 // outlast one interactive authorization; it is kept short to limit the lifetime
-// of the throwaway key. NotBefore is also backdated by the same margin so a
-// modest client/server clock skew cannot reject an otherwise-valid cert.
+// of the throwaway key.
 const loopbackCertTTL = 24 * time.Hour
+
+// loopbackClockSkew backdates NotBefore by a small margin so a modest
+// client/server clock skew cannot reject an otherwise-valid cert. It is kept
+// far smaller than loopbackCertTTL so the effective validity window stays close
+// to loopbackCertTTL rather than doubling it.
+const loopbackClockSkew = 5 * time.Minute
 
 // GenerateLoopbackCert mints a self-signed certificate (with its private key)
 // for the loopback callback server, entirely in memory — nothing is written to
@@ -43,17 +48,20 @@ func GenerateLoopbackCert() (tls.Certificate, error) {
 	// A random 128-bit serial (rather than a fixed value) matches mkcert and the
 	// CA/Browser Forum guidance, so two concurrently generated certs never share
 	// a serial.
+	// rand.Int returns a value in [0, max); X.509 serials must be positive, so
+	// sample from [1, max) by adding one to a [0, max-1) draw.
 	serialMax := new(big.Int).Lsh(big.NewInt(1), 128)
-	serial, err := rand.Int(rand.Reader, serialMax)
+	serial, err := rand.Int(rand.Reader, new(big.Int).Sub(serialMax, big.NewInt(1)))
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("oauth: generate serial: %w", err)
 	}
+	serial.Add(serial, big.NewInt(1))
 
 	now := time.Now()
 	tmpl := x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: "127.0.0.1"},
-		NotBefore:    now.Add(-loopbackCertTTL),
+		NotBefore:    now.Add(-loopbackClockSkew),
 		NotAfter:     now.Add(loopbackCertTTL),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -68,9 +76,17 @@ func GenerateLoopbackCert() (tls.Certificate, error) {
 		return tls.Certificate{}, fmt.Errorf("oauth: create loopback certificate: %w", err)
 	}
 
+	// Parse the DER we just produced so Leaf is a real parsed certificate (with
+	// Raw and friends populated), not the template struct — the latter would
+	// mislead any code that later inspects cert.Leaf.
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("oauth: parse loopback certificate: %w", err)
+	}
+
 	return tls.Certificate{
 		Certificate: [][]byte{der},
 		PrivateKey:  key,
-		Leaf:        &tmpl,
+		Leaf:        leaf,
 	}, nil
 }

--- a/pkg/oauth/cert.go
+++ b/pkg/oauth/cert.go
@@ -1,0 +1,76 @@
+package oauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// loopbackCertTTL bounds the validity of a generated callback certificate. A
+// fresh cert is minted on every login, so the window only needs to comfortably
+// outlast one interactive authorization; it is kept short to limit the lifetime
+// of the throwaway key. NotBefore is also backdated by the same margin so a
+// modest client/server clock skew cannot reject an otherwise-valid cert.
+const loopbackCertTTL = 24 * time.Hour
+
+// GenerateLoopbackCert mints a self-signed certificate (with its private key)
+// for the loopback callback server, entirely in memory — nothing is written to
+// disk or baked into the binary.
+//
+// It exists so the https callback (which Jira DC requires, since it commonly
+// rejects an http redirect URI) works with zero setup: the user does not need
+// mkcert or any pre-provisioned cert/key files. The trade-off is that the cert
+// is not signed by a CA in the system trust store, so the browser shows a
+// one-time security warning the user must accept; on 127.0.0.1 this is a single
+// "proceed anyway" click.
+//
+// The certificate template follows the conventions a tool like mkcert uses for
+// a leaf cert: a random serial, SANs covering both the loopback IP literals and
+// "localhost", and the ServerAuth extended key usage browsers require.
+func GenerateLoopbackCert() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("oauth: generate loopback key: %w", err)
+	}
+
+	// A random 128-bit serial (rather than a fixed value) matches mkcert and the
+	// CA/Browser Forum guidance, so two concurrently generated certs never share
+	// a serial.
+	serialMax := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialMax)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("oauth: generate serial: %w", err)
+	}
+
+	now := time.Now()
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    now.Add(-loopbackCertTTL),
+		NotAfter:     now.Add(loopbackCertTTL),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		// The callback server binds 127.0.0.1, but cover ::1 and localhost too so
+		// the same cert stays valid if the loopback host ever broadens.
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:    []string{"localhost"},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("oauth: create loopback certificate: %w", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        &tmpl,
+	}, nil
+}

--- a/pkg/oauth/cert.go
+++ b/pkg/oauth/cert.go
@@ -60,7 +60,7 @@ func GenerateLoopbackCert() (tls.Certificate, error) {
 	now := time.Now()
 	tmpl := x509.Certificate{
 		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		Subject:      pkix.Name{CommonName: loopbackHost},
 		NotBefore:    now.Add(-loopbackClockSkew),
 		NotAfter:     now.Add(loopbackCertTTL),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -49,12 +49,20 @@ type Config struct {
 	TLSCertFile string
 	TLSKeyFile  string
 
+	// GenerateTLSCert, when true, makes the callback server serve HTTPS using a
+	// self-signed loopback certificate minted in memory at login time (see
+	// GenerateLoopbackCert), so an https callback works with no pre-provisioned
+	// cert/key files. The browser shows a one-time security warning to accept.
+	// Explicit TLSCertFile/TLSKeyFile take precedence when both are also set.
+	GenerateTLSCert bool
+
 	HTTPClient *http.Client // optional; defaults to a 30s-timeout client
 }
 
-// useTLS reports whether the callback server should serve HTTPS.
+// useTLS reports whether the callback server should serve HTTPS — either from a
+// supplied key pair or a generated in-memory loopback cert.
 func (c *Config) useTLS() bool {
-	return c.TLSCertFile != "" && c.TLSKeyFile != ""
+	return c.GenerateTLSCert || (c.TLSCertFile != "" && c.TLSKeyFile != "")
 }
 
 // Validate checks that the fields required to start a flow are present.

--- a/pkg/oauth/login.go
+++ b/pkg/oauth/login.go
@@ -85,7 +85,15 @@ func Login(
 	}
 	verifier := NewVerifier()
 
-	resultCh, shutdown, err := startCallbackServer(port, state, cfg.TLSCertFile, cfg.TLSKeyFile)
+	// Resolve the callback certificate before binding the listener so a bad/
+	// missing cert (or a key-generation failure) fails fast here rather than
+	// being swallowed by the Serve goroutine and surfacing as a hung redirect.
+	cert, err := cfg.resolveCallbackCert()
+	if err != nil {
+		return nil, fmt.Errorf("oauth login: %w", err)
+	}
+
+	resultCh, shutdown, err := startCallbackServer(port, state, cert)
 	if err != nil {
 		return nil, fmt.Errorf("oauth login: start callback server: %w", err)
 	}

--- a/pkg/oauth/login.go
+++ b/pkg/oauth/login.go
@@ -49,9 +49,11 @@ func Login(
 	if err != nil {
 		return nil, fmt.Errorf("oauth login: invalid redirect URI %q: %w", cfg.RedirectURI, err)
 	}
-	// The callback server serves plain HTTP by default and HTTPS only when a TLS
-	// key pair is configured; the redirect URI's scheme must match what it
-	// actually speaks, or the browser redirect fails to connect.
+	// The callback server serves plain HTTP by default and HTTPS when TLS is
+	// configured — either via a cert/key pair or a generated in-memory cert
+	// (GenerateTLSCert, the --callback-https path). The redirect URI's scheme
+	// must match what it actually speaks, or the browser redirect fails to
+	// connect.
 	wantScheme := "http"
 	if cfg.useTLS() {
 		wantScheme = "https"

--- a/pkg/oauth/login.go
+++ b/pkg/oauth/login.go
@@ -90,7 +90,7 @@ func Login(
 	// being swallowed by the Serve goroutine and surfacing as a hung redirect.
 	cert, err := cfg.resolveCallbackCert()
 	if err != nil {
-		return nil, fmt.Errorf("oauth login: %w", err)
+		return nil, fmt.Errorf("oauth login: resolve callback certificate: %w", err)
 	}
 
 	resultCh, shutdown, err := startCallbackServer(port, state, cert)

--- a/pkg/oauth/login.go
+++ b/pkg/oauth/login.go
@@ -64,7 +64,7 @@ func Login(
 			cfg.RedirectURI, wantScheme, strings.ToUpper(wantScheme),
 		)
 	}
-	if redirect.Hostname() != "127.0.0.1" {
+	if redirect.Hostname() != loopbackHost {
 		return nil, fmt.Errorf(
 			"oauth login: redirect URI %q host must be 127.0.0.1 (the callback server binds loopback)",
 			cfg.RedirectURI,

--- a/pkg/oauth/login_test.go
+++ b/pkg/oauth/login_test.go
@@ -239,8 +239,9 @@ func mustECKeyPEM(t *testing.T, cert tls.Certificate) []byte {
 }
 
 // TestLoginEndToEndGeneratedTLS exercises the full flow against an HTTPS
-// callback whose certificate is generated in memory via GenerateTLSCert (the
-// --callback-https path), with no cert/key files supplied.
+// callback whose certificate is generated in memory by GenerateLoopbackCert
+// (triggered by Config.GenerateTLSCert, the --callback-https path), with no
+// cert/key files supplied.
 func TestLoginEndToEndGeneratedTLS(t *testing.T) {
 	srv := tokenServer(t, func(_ *testing.T, w http.ResponseWriter, form map[string][]string) {
 		if got := form["code"]; len(got) != 1 || got[0] != "browser-code" {

--- a/pkg/oauth/login_test.go
+++ b/pkg/oauth/login_test.go
@@ -181,6 +181,120 @@ func TestLoginEndToEndTLS(t *testing.T) {
 	}
 }
 
+// TestGenerateLoopbackCert verifies the in-memory cert minted for the
+// --callback-https flow is well-formed: it parses, covers the loopback IP and
+// carries the ServerAuth usage browsers require.
+func TestGenerateLoopbackCert(t *testing.T) {
+	cert, err := GenerateLoopbackCert()
+	if err != nil {
+		t.Fatalf("GenerateLoopbackCert: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("no certificate bytes produced")
+	}
+	// The generated cert must be usable as a server certificate in a TLS config.
+	if _, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}),
+		mustECKeyPEM(t, cert),
+	); err != nil {
+		t.Fatalf("generated cert is not a valid key pair: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	hasLoopbackIP := false
+	for _, ip := range leaf.IPAddresses {
+		if ip.Equal(net.IPv4(127, 0, 0, 1)) {
+			hasLoopbackIP = true
+		}
+	}
+	if !hasLoopbackIP {
+		t.Errorf("leaf missing 127.0.0.1 IP SAN, got %v", leaf.IPAddresses)
+	}
+	hasServerAuth := false
+	for _, eku := range leaf.ExtKeyUsage {
+		if eku == x509.ExtKeyUsageServerAuth {
+			hasServerAuth = true
+		}
+	}
+	if !hasServerAuth {
+		t.Error("leaf missing ExtKeyUsageServerAuth")
+	}
+}
+
+// mustECKeyPEM marshals the cert's ECDSA private key to PEM for re-loading.
+func mustECKeyPEM(t *testing.T, cert tls.Certificate) []byte {
+	t.Helper()
+	key, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		t.Fatalf("private key is %T, want *ecdsa.PrivateKey", cert.PrivateKey)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+// TestLoginEndToEndGeneratedTLS exercises the full flow against an HTTPS
+// callback whose certificate is generated in memory via GenerateTLSCert (the
+// --callback-https path), with no cert/key files supplied.
+func TestLoginEndToEndGeneratedTLS(t *testing.T) {
+	srv := tokenServer(t, func(_ *testing.T, w http.ResponseWriter, form map[string][]string) {
+		if got := form["code"]; len(got) != 1 || got[0] != "browser-code" {
+			t.Errorf("code = %v, want [browser-code]", got)
+		}
+		writeToken(w, oauth2.Token{AccessToken: "access-final"}, "refresh-final")
+	})
+	defer srv.Close()
+
+	port := freePort(t)
+	cfg := testConfig(srv.URL)
+	cfg.RedirectURI = fmt.Sprintf("https://127.0.0.1:%d/callback", port)
+	cfg.GenerateTLSCert = true
+
+	// Browser stub fires the redirect at the HTTPS callback over a TLS client.
+	orig := browserCommand
+	t.Cleanup(func() { browserCommand = orig })
+	browserCommand = func(rawURL string) (string, []string, error) {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			t.Errorf("parse authorize url: %v", err)
+		}
+		state := u.Query().Get("state")
+		query := fmt.Sprintf("code=browser-code&state=%s", url.QueryEscape(state))
+		go getCallbackTLS(t, port, query)
+		return "", nil, errors.New("browser stubbed")
+	}
+
+	res, err := Login(context.Background(), cfg, port, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if res.Token.AccessToken != "access-final" {
+		t.Errorf("access token = %q, want access-final", res.Token.AccessToken)
+	}
+}
+
+// TestLoginGeneratedTLSSchemeMismatch verifies that enabling GenerateTLSCert
+// (https callback) but leaving an http redirect URI fails fast with a clear
+// scheme-mismatch error rather than hanging.
+func TestLoginGeneratedTLSSchemeMismatch(t *testing.T) {
+	cfg := testConfig("https://jira.example.com")
+	cfg.RedirectURI = "http://127.0.0.1:8765/callback"
+	cfg.GenerateTLSCert = true
+
+	_, err := Login(context.Background(), cfg, 8765, time.Second)
+	if err == nil {
+		t.Fatal("expected error when GenerateTLSCert is set but redirect URI scheme is http")
+	}
+	if !strings.Contains(err.Error(), "scheme must be https") {
+		t.Errorf("error = %q, want a scheme-mismatch message", err.Error())
+	}
+}
+
 // TestLoginTLSSchemeMismatch verifies that when a TLS pair is configured the
 // redirect URI must use https, not http.
 func TestLoginTLSSchemeMismatch(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds a `--callback-https` flag (env: `JIRA_OAUTH_CALLBACK_HTTPS`) that serves the OAuth login callback over HTTPS using a self-signed `127.0.0.1` certificate **generated in memory at login time**. This lets a single shared binary do the https callback Jira DC requires with zero per-user setup — no `mkcert`, no cert/key files, and no private key baked into the binary. Default-off and fully backward compatible with the existing `--callback-cert` / `--callback-key` file-based path.

## AI Authorship
- [ ] No AI was used in this PR
- [x] AI was used. Details:
  - **Tool / model**: Claude Code (Opus 4.7)
  - **AI-authored files**: all files in this PR
  - **Human line-by-line reviewed**: none yet — relying on PR review. Please scrutinise `pkg/oauth/cert.go` and the cert-resolution change in `pkg/oauth/callback.go` / `login.go`.

## Change classification
- [x] Core code (broad impact — needs line-by-line review)
  - Touches the OAuth login path (`pkg/oauth`). Additive and default-off, but auth-adjacent, so reviewed as core.

## Plan reference
Goal: make the https OAuth callback work out-of-the-box for a tool shared across a team, without each colleague generating/managing their own loopback certificate. Decision (with maintainer): generate the cert in memory rather than embedding a fixed cert/key or installing a local CA (mkcert-style), accepting a one-time browser warning instead of pulling in a trust-store dependency.

## Verification
- [x] Unit tests — `TestGenerateLoopbackCert` (cert is well-formed: parses, 127.0.0.1 SAN, ServerAuth), `TestRedirectURI` (new https case), `TestResolveCallbackHTTPS` (env > flag precedence)
- [x] Integration / e2e tests — `TestLoginEndToEndGeneratedTLS` (full login over a generated-cert https callback, happy path), `TestLoginGeneratedTLSSchemeMismatch` (http redirect URI + generated cert fails fast)
- [x] At least 3 e2e/behavioural tests (1 happy path + error/edge cases)
- [ ] Stress / soak test: N/A (interactive one-shot flow)
- Manual verification: register `https://127.0.0.1:8765/callback` in Jira, then `go-jira login --callback-https` → browser shows a one-time warning → "Proceed to 127.0.0.1" → terminal prints login success. `gofmt`, `go vet ./...`, `go build ./...`, `go test ./...` all pass.

## Verifiability check
- [x] Inputs and outputs are documented (flag/env in README, docs/oauth-usage.md, .env.example)
- [x] Reviewer can judge correctness from tests + signatures
- [x] Failures surface clearly (cert resolution fails fast before the listener binds; redirect-URI scheme validated up front)

## Security check
- [x] No secrets in code — the cert/key are generated at runtime in memory; nothing is committed or embedded
- [x] External inputs validated — redirect URI scheme/host/port/path validated before serving; callback port range-checked
- [x] Errors don't leak internals
- Note: the generated cert is self-signed, so the browser shows a one-time warning the user accepts on 127.0.0.1. Documented as an explicit trade-off; the `mkcert`-based path remains available for a warning-free experience.

## Risk & rollback
- **Risk**: changing `startCallbackServer`'s signature (now takes an in-memory `*tls.Certificate`) touches the existing file-based https path. Mitigated by routing files / generated / http through one resolution point and keeping existing tests green.
- **Rollback**: feature is additive and default-off; revert this single commit to restore prior behaviour.

## Reviewer guide
- **Read carefully**: `pkg/oauth/cert.go` (cert template / key usage / SANs), `pkg/oauth/callback.go` (`resolveCallbackCert` + the http-vs-TLS serve branch), `pkg/oauth/login.go` (fail-fast cert resolution before binding).
- **Spot-check OK**: CLI wiring (`cmd/go-jira/*`), docs, and tests — covered by the signatures and the test suite.

Suggested reviewers: 2+ (including the auth/oauth module owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
