### PR TITLE
refactor(oauth)!: drop client secret from OAuth flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,8 @@ JIRA_TOKEN=
 
 # Mode 3: OAuth, local dev — run `go-jira login`; the token is stored in your
 # OS keyring (or an encrypted file). No env vars needed unless you override the
-# embedded client credentials below.
+# embedded client ID below. go-jira is a public PKCE client, so no secret.
 # JIRA_OAUTH_CLIENT_ID=
-# JIRA_OAUTH_CLIENT_SECRET=
 # Override the local callback port (default 8765); the redirect URI registered
 # in Jira must match.
 # JIRA_OAUTH_CALLBACK_PORT=8765
@@ -41,7 +40,6 @@ JIRA_TOKEN=
 # token on every refresh, so write the new one back to your secret store via
 # JIRA_OAUTH_REFRESH_TOKEN_OUTPUT. See docs/oauth-usage.md.
 # JIRA_OAUTH_CLIENT_ID=
-# JIRA_OAUTH_CLIENT_SECRET=
 # JIRA_OAUTH_REFRESH_TOKEN=
 # JIRA_OAUTH_REFRESH_TOKEN_OUTPUT=.jira-refresh-token
 

--- a/.github/workflows/example-oauth-ci.yml
+++ b/.github/workflows/example-oauth-ci.yml
@@ -25,12 +25,11 @@ jobs:
         env:
           JIRA_BASE_URL: https://jira.example.com
           JIRA_OAUTH_CLIENT_ID: ${{ secrets.JIRA_OAUTH_CLIENT_ID }}
-          JIRA_OAUTH_CLIENT_SECRET: ${{ secrets.JIRA_OAUTH_CLIENT_SECRET }}
           JIRA_OAUTH_REFRESH_TOKEN: ${{ secrets.JIRA_OAUTH_REFRESH_TOKEN }}
           JIRA_OAUTH_REFRESH_TOKEN_OUTPUT: ${{ runner.temp }}/new-refresh-token
         run: |
           docker run --rm \
-            -e JIRA_BASE_URL -e JIRA_OAUTH_CLIENT_ID -e JIRA_OAUTH_CLIENT_SECRET \
+            -e JIRA_BASE_URL -e JIRA_OAUTH_CLIENT_ID \
             -e JIRA_OAUTH_REFRESH_TOKEN -e JIRA_OAUTH_REFRESH_TOKEN_OUTPUT \
             -v "${{ runner.temp }}:${{ runner.temp }}" \
             ghcr.io/appleboy/go-jira:latest run \

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,12 +61,11 @@ builds:
       - -s -w
       - -X main.Version={{.Version}}
       - -X main.Commit={{.ShortCommit}}
-      # Embed the company-wide OAuth client. PKCE protects the actual flow, so
-      # the secret is a soft secret; inject both from CI secrets at release
-      # time. `index` yields "" when the env var is unset, so snapshot builds
-      # without the secrets still succeed (OAuth login then needs --client-id).
+      # Embed the company-wide OAuth client. The flow is a public PKCE client,
+      # so there is no secret; inject the client ID from CI at release time.
+      # `index` yields "" when the env var is unset, so snapshot builds without
+      # it still succeed (OAuth login then needs --client-id).
       - -X main.DefaultOAuthClientID={{ index .Env "JIRA_OAUTH_CLIENT_ID" }}
-      - -X main.DefaultOAuthClientSecret={{ index .Env "JIRA_OAUTH_CLIENT_SECRET" }}
     binary: >-
       {{ .ProjectName }}-
       {{- if .IsSnapshot }}{{ .Branch }}-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Removed the OAuth client secret entirely.** go-jira is a public PKCE client,
+  so no secret is needed for either interactive login or CI refresh-token
+  injection (`oauth-env` mode). This is a breaking change: the
+  `JIRA_OAUTH_CLIENT_SECRET` environment variable, the `--client-secret` flag,
+  and the `DefaultOAuthClientSecret` build-time ldflag are gone. Drop them from
+  your build, env, and CI configuration; nothing else about the OAuth flows
+  changes.
+
 ## v0.8.0 - 2026-05-25
 
 ### Commands

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,9 @@ LDFLAGS ?= -X 'main.Version=$(VERSION)' -X 'main.Commit=$(COMMIT)'
 
 # Optional build-time OAuth client injection (decision 3.2). Leave unset for
 # local/dev builds; OAuth login then requires --client-id / JIRA_OAUTH_CLIENT_ID.
+# The flow is a public PKCE client, so there is no client secret.
 JIRA_OAUTH_CLIENT_ID ?=
-JIRA_OAUTH_CLIENT_SECRET ?=
 LDFLAGS += -X 'main.DefaultOAuthClientID=$(JIRA_OAUTH_CLIENT_ID)'
-LDFLAGS += -X 'main.DefaultOAuthClientSecret=$(JIRA_OAUTH_CLIENT_SECRET)'
 
 ifneq ($(shell uname), Darwin)
 	EXTLDFLAGS = -extldflags "-static" $(null)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ go-jira supports four authentication modes:
 | EPIC_FIELD                      | Epic Link custom field ID used by `create`/`update`/`search` (default `customfield_10101`)                                 |
 | SPRINT_FIELD                    | Sprint custom field ID used by `create`/`update`/`search` (default `customfield_10100`)                                    |
 | JIRA_OAUTH_CLIENT_ID            | OAuth client ID (overrides the embedded default)                                                                           |
-| JIRA_OAUTH_CLIENT_SECRET        | OAuth client secret (overrides the embedded default)                                                                       |
 | JIRA_OAUTH_REFRESH_TOKEN        | Injected refresh token; triggers CI `oauth-env` mode                                                                       |
 | JIRA_OAUTH_REFRESH_TOKEN_OUTPUT | File path to write the rotated refresh token                                                                               |
 | JIRA_OAUTH_CALLBACK_PORT        | Local OAuth callback port (default `8765`)                                                                                 |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -117,7 +117,6 @@ go-jira 支持四种认证模式：
 | MARKDOWN                        | 设为 `true` 时将评论从 Markdown 转为 Jira 格式     |
 | DEBUG                           | 设为 `true` 启用调试输出                           |
 | JIRA_OAUTH_CLIENT_ID            | OAuth client ID（覆盖内嵌默认值）                  |
-| JIRA_OAUTH_CLIENT_SECRET        | OAuth client secret（覆盖内嵌默认值）              |
 | JIRA_OAUTH_REFRESH_TOKEN        | 注入的 refresh token；触发 CI `oauth-env` 模式     |
 | JIRA_OAUTH_REFRESH_TOKEN_OUTPUT | 写入轮换后 refresh token 的文件路径                |
 | JIRA_MASTER_PASSWORD            | 加密文件 token 存储的主密码（无 keyring 时）       |

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -117,7 +117,6 @@ go-jira 支援四種認證模式：
 | MARKDOWN                        | 設為 `true` 時將評論從 Markdown 轉為 Jira 格式     |
 | DEBUG                           | 設為 `true` 啟用除錯輸出                           |
 | JIRA_OAUTH_CLIENT_ID            | OAuth client ID（覆寫內嵌預設值）                  |
-| JIRA_OAUTH_CLIENT_SECRET        | OAuth client secret（覆寫內嵌預設值）              |
 | JIRA_OAUTH_REFRESH_TOKEN        | 注入的 refresh token；觸發 CI `oauth-env` 模式     |
 | JIRA_OAUTH_REFRESH_TOKEN_OUTPUT | 寫入輪換後 refresh token 的檔案路徑                |
 | JIRA_MASTER_PASSWORD            | 加密檔 token 儲存的主密碼（無 keyring 時）         |

--- a/cmd/go-jira/apiclient.go
+++ b/cmd/go-jira/apiclient.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/appleboy/go-jira/pkg/auth"
 
 	jira "github.com/andygrunwald/go-jira"

--- a/cmd/go-jira/ci_oauth_test.go
+++ b/cmd/go-jira/ci_oauth_test.go
@@ -80,7 +80,6 @@ func TestRunOAuthEnvMode(t *testing.T) {
 	t.Setenv("INPUT_INSECURE", "true")
 	t.Setenv("INPUT_REF", "ABC-123")
 	t.Setenv(envOAuthClientID, "client-abc")
-	t.Setenv(envOAuthClientSecret, "secret-xyz")
 	t.Setenv(envOAuthRefreshToken, "injected-refresh")
 	t.Setenv(envOAuthRefreshTokenOutput, out)
 
@@ -105,7 +104,6 @@ func TestRunOAuthEnvInvalidGrant(t *testing.T) {
 	t.Setenv("INPUT_INSECURE", "true")
 	t.Setenv("INPUT_REF", "ABC-123")
 	t.Setenv(envOAuthClientID, "client-abc")
-	t.Setenv(envOAuthClientSecret, "secret-xyz")
 	t.Setenv(envOAuthRefreshToken, "dead-refresh")
 
 	err := run(nil)

--- a/cmd/go-jira/cli_test.go
+++ b/cmd/go-jira/cli_test.go
@@ -3,14 +3,15 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/appleboy/go-jira/pkg/oauth"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/oauth"
+	"github.com/appleboy/go-jira/pkg/storage"
 
 	jira "github.com/andygrunwald/go-jira"
 	keyring "github.com/zalando/go-keyring"

--- a/cmd/go-jira/client.go
+++ b/cmd/go-jira/client.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/auth"
 	"log/slog"
 	"net/http"
 	"strings"
+
+	"github.com/appleboy/go-jira/pkg/auth"
 
 	jira "github.com/andygrunwald/go-jira"
 )

--- a/cmd/go-jira/client_test.go
+++ b/cmd/go-jira/client_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/appleboy/go-jira/pkg/auth"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/appleboy/go-jira/pkg/auth"
 
 	jira "github.com/andygrunwald/go-jira"
 )

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -40,7 +40,6 @@ type Config struct {
 
 	// OAuth
 	oauthClientID           string
-	oauthClientSecret       string
 	oauthRefreshToken       string
 	oauthRefreshTokenOutput string
 	scope                   string
@@ -130,9 +129,6 @@ func loadConfig(cmd *cobra.Command) Config {
 	cfg.oauthClientID = resolveWithEnv(
 		envOAuthClientID, flagStringValue(cmd, flagClientID), DefaultOAuthClientID,
 	)
-	cfg.oauthClientSecret = resolveWithEnv(
-		envOAuthClientSecret, flagStringValue(cmd, flagClientSecret), DefaultOAuthClientSecret,
-	)
 	cfg.oauthRefreshToken = os.Getenv(envOAuthRefreshToken)
 	cfg.oauthRefreshTokenOutput = os.Getenv(envOAuthRefreshTokenOutput)
 	cfg.scope = defaultScope
@@ -141,7 +137,7 @@ func loadConfig(cmd *cobra.Command) Config {
 	}
 	cfg.callbackPort = resolveCallbackPort(cmd)
 	// Callback TLS cert/key are public file paths, so the flag is fine; resolve
-	// env > flag (matching the client-id/secret precedence) with no embedded
+	// env > flag (matching the client-id precedence) with no embedded
 	// default — empty means a plain-HTTP callback.
 	cfg.callbackCert = resolveWithEnv(
 		envOAuthCallbackCert, flagStringValue(cmd, flagCallbackCert), "",
@@ -161,7 +157,7 @@ func warnOnSecretFlags(cmd *cobra.Command) {
 	if cmd == nil {
 		return
 	}
-	for _, name := range []string{flagPassword, flagToken, flagClientSecret} {
+	for _, name := range []string{flagPassword, flagToken} {
 		if cmd.Flags().Lookup(name) != nil && cmd.Flags().Changed(name) {
 			slog.Warn(
 				"passing secrets via CLI flag is unsafe on shared hosts; prefer env vars or .env",
@@ -255,7 +251,7 @@ func resolveCallbackHTTPS(cmd *cobra.Command) bool {
 }
 
 // resolveWithEnv applies the env > flag > embedded-default precedence used for
-// the OAuth client ID and secret.
+// the OAuth client ID.
 func resolveWithEnv(envKey, flagVal, embedded string) string {
 	if v := os.Getenv(envKey); v != "" {
 		return v

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/util"
 	"log/slog"
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/appleboy/go-jira/pkg/util"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -66,10 +66,6 @@ func runConfigShow(cmd *cobra.Command) error {
 		redactIfSecret("oauth_client_id", config.oauthClientID),
 		oauthValueSource(cmd, flagClientID, envOAuthClientID, config.oauthClientID,
 			DefaultOAuthClientID))
-	fmt.Fprintf(w, "oauth_client_secret\t%s\t%s\n",
-		redactIfSecret("oauth_client_secret", config.oauthClientSecret),
-		oauthValueSource(cmd, flagClientSecret, envOAuthClientSecret,
-			config.oauthClientSecret, DefaultOAuthClientSecret))
 	row("scope", config.scope, flagScope, "", "")
 	// oauth-env (CI) inputs: show presence/source without leaking the token.
 	fmt.Fprintf(w, "oauth_refresh_token\t%s\t%s\n",
@@ -167,8 +163,7 @@ func redactIfSecret(field, value string) string {
 		return "(unset)"
 	}
 	switch field {
-	case flagToken, flagPassword, "client_secret",
-		"oauth_client_secret", "oauth_refresh_token":
+	case flagToken, flagPassword, "oauth_refresh_token":
 		return "(set, redacted)"
 	default:
 		return value

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
+
 	"github.com/appleboy/go-jira/pkg/auth"
 	"github.com/appleboy/go-jira/pkg/storage"
 	"github.com/appleboy/go-jira/pkg/util"
-	"os"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/go-jira/login.go
+++ b/cmd/go-jira/login.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"os"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/storage"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/go-jira/logout.go
+++ b/cmd/go-jira/logout.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"os"
+
+	"github.com/appleboy/go-jira/pkg/storage"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -14,13 +14,11 @@ var (
 	Version string
 	Commit  string
 
-	// DefaultOAuthClientID and DefaultOAuthClientSecret are injected at build
-	// time via -ldflags (see .goreleaser.yaml / Makefile). They are the
-	// company-wide OAuth client baked into the binary; PKCE protects the actual
-	// flow, so the secret is treated as a soft secret. Runtime resolution order
-	// is env var > CLI flag > these embedded defaults.
-	DefaultOAuthClientID     string
-	DefaultOAuthClientSecret string
+	// DefaultOAuthClientID is injected at build time via -ldflags (see
+	// .goreleaser.yaml / Makefile). It is the company-wide OAuth client baked
+	// into the binary; the flow is a public PKCE client, so there is no secret.
+	// Runtime resolution order is env var > CLI flag > this embedded default.
+	DefaultOAuthClientID string
 )
 
 // Flag names shared between registration and lookup. Keeping them here avoids
@@ -65,7 +63,6 @@ const (
 
 	// OAuth-related flags.
 	flagClientID      = "client-id"
-	flagClientSecret  = "client-secret"
 	flagCallbackPort  = "callback-port"
 	flagCallbackCert  = "callback-cert"
 	flagCallbackKey   = "callback-key"
@@ -80,7 +77,6 @@ const (
 // use fixed JIRA_-prefixed names matching the documented CI/CD contract.
 const (
 	envOAuthClientID           = "JIRA_OAUTH_CLIENT_ID"
-	envOAuthClientSecret       = "JIRA_OAUTH_CLIENT_SECRET"        //nolint:gosec // env var name, not a secret
 	envOAuthRefreshToken       = "JIRA_OAUTH_REFRESH_TOKEN"        //nolint:gosec // env var name, not a secret
 	envOAuthRefreshTokenOutput = "JIRA_OAUTH_REFRESH_TOKEN_OUTPUT" //nolint:gosec // env var name, not a secret
 	envOAuthCallbackPort       = "JIRA_OAUTH_CALLBACK_PORT"
@@ -220,8 +216,6 @@ func addCommonFlags(cmd *cobra.Command) {
 // addOAuthFlags registers the OAuth client flags shared by login and run.
 func addOAuthFlags(cmd *cobra.Command) {
 	cmd.Flags().String(flagClientID, "", "OAuth client ID (env: "+envOAuthClientID+")")
-	cmd.Flags().
-		String(flagClientSecret, "", "OAuth client secret (env: "+envOAuthClientSecret+")")
 	cmd.Flags().
 		Int(flagCallbackPort, defaultCallbackPort, "Local OAuth callback port (env: "+envOAuthCallbackPort+")")
 	cmd.Flags().String(flagCallbackCert, "",

--- a/cmd/go-jira/oauthcli.go
+++ b/cmd/go-jira/oauthcli.go
@@ -140,7 +140,6 @@ func oauthConfigFromConfig(config Config) *oauth.Config {
 	return &oauth.Config{
 		BaseURL:         config.baseURL,
 		ClientID:        config.oauthClientID,
-		ClientSecret:    config.oauthClientSecret,
 		RedirectURI:     config.redirectURI(),
 		Scopes:          []string{config.scope},
 		TLSCertFile:     config.callbackCert,

--- a/cmd/go-jira/oauthcli.go
+++ b/cmd/go-jira/oauthcli.go
@@ -3,13 +3,14 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/oauth"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/oauth"
+	"github.com/appleboy/go-jira/pkg/storage"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/go-jira/run.go
+++ b/cmd/go-jira/run.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/auth"
-	"github.com/appleboy/go-jira/pkg/markdown"
 	"log/slog"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/auth"
+	"github.com/appleboy/go-jira/pkg/markdown"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/spf13/cobra"

--- a/cmd/go-jira/run.go
+++ b/cmd/go-jira/run.go
@@ -171,7 +171,6 @@ func authConfigFromRun(config Config) auth.Config {
 		Token:             config.token,
 		OAuthRefreshToken: config.oauthRefreshToken,
 		OAuthClientID:     config.oauthClientID,
-		OAuthClientSecret: config.oauthClientSecret,
 		OAuthBaseURL:      config.baseURL,
 		OAuthRedirectURI:  config.redirectURI(),
 		OAuthScopes:       []string{config.scope},

--- a/cmd/go-jira/token.go
+++ b/cmd/go-jira/token.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/auth"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"os"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/auth"
+	"github.com/appleboy/go-jira/pkg/storage"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/go-jira/whoami.go
+++ b/cmd/go-jira/whoami.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/auth"
 	"os"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/auth"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/spf13/cobra"

--- a/docs/oauth-usage.md
+++ b/docs/oauth-usage.md
@@ -134,6 +134,7 @@ refresh token for an access token at startup.
 
 | Env var                           | Required             | Purpose                                 |
 | --------------------------------- | -------------------- | --------------------------------------- |
+| `JIRA_BASE_URL`                   | yes                  | Jira instance base URL                  |
 | `JIRA_OAUTH_CLIENT_ID`            | yes                  | OAuth client ID                         |
 | `JIRA_OAUTH_REFRESH_TOKEN`        | yes                  | Triggers `oauth-env` mode               |
 | `JIRA_OAUTH_REFRESH_TOKEN_OUTPUT` | strongly recommended | File to write the rotated refresh token |

--- a/docs/oauth-usage.md
+++ b/docs/oauth-usage.md
@@ -66,11 +66,12 @@ completes normally. If you want to avoid the warning entirely, use the
 When both `--callback-https` and an explicit `--callback-cert` / `--callback-key`
 pair are given, the supplied files win.
 
-You then have a **client ID** and **client secret**. These can be:
+You then have a **client ID**. go-jira uses a public PKCE client, so **no client
+secret is needed**. The client ID can be:
 
 1. embedded into the binary at build time (see [Building with an embedded client](#building-with-an-embedded-client)), or
-2. supplied at runtime via `JIRA_OAUTH_CLIENT_ID` / `JIRA_OAUTH_CLIENT_SECRET`, or
-3. passed as `--client-id` / `--client-secret`.
+2. supplied at runtime via `JIRA_OAUTH_CLIENT_ID`, or
+3. passed as `--client-id`.
 
 Resolution order is **env var > flag > embedded default**.
 
@@ -134,7 +135,6 @@ refresh token for an access token at startup.
 | Env var                           | Required             | Purpose                                 |
 | --------------------------------- | -------------------- | --------------------------------------- |
 | `JIRA_OAUTH_CLIENT_ID`            | yes                  | OAuth client ID                         |
-| `JIRA_OAUTH_CLIENT_SECRET`        | yes                  | OAuth client secret                     |
 | `JIRA_OAUTH_REFRESH_TOKEN`        | yes                  | Triggers `oauth-env` mode               |
 | `JIRA_OAUTH_REFRESH_TOKEN_OUTPUT` | strongly recommended | File to write the rotated refresh token |
 
@@ -153,11 +153,9 @@ A complete GitHub Actions example, including the secret write-back step, is in
 To ship a binary with the company-wide client baked in:
 
 ```bash
-make build \
-  JIRA_OAUTH_CLIENT_ID="$JIRA_OAUTH_CLIENT_ID" \
-  JIRA_OAUTH_CLIENT_SECRET="$JIRA_OAUTH_CLIENT_SECRET"
+make build JIRA_OAUTH_CLIENT_ID="$JIRA_OAUTH_CLIENT_ID"
 ```
 
-The release pipeline injects the same values via goreleaser ldflags from CI
-secrets. PKCE protects the actual authorization flow, so the embedded secret is
-treated as a *soft* secret; a Jira admin can revoke the client at any time.
+The release pipeline injects the same value via goreleaser ldflags from CI.
+There is no client secret — PKCE protects the authorization flow, and the client
+ID is not sensitive; a Jira admin can revoke the client at any time.

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/oauth"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"io"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/oauth"
+	"github.com/appleboy/go-jira/pkg/storage"
 )
 
 // refreshThreshold is how long before expiry a token is proactively refreshed,

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -88,11 +88,10 @@ func newOAuthMockServer(t *testing.T) *oauthMockServer {
 
 func (s *oauthMockServer) config() *oauth.Config {
 	return &oauth.Config{
-		BaseURL:      s.URL,
-		ClientID:     "client-abc",
-		ClientSecret: "secret-xyz",
-		RedirectURI:  "http://127.0.0.1:8765/callback",
-		Scopes:       []string{"WRITE"},
+		BaseURL:     s.URL,
+		ClientID:    "client-abc",
+		RedirectURI: "http://127.0.0.1:8765/callback",
+		Scopes:      []string{"WRITE"},
 	}
 }
 
@@ -242,7 +241,7 @@ func TestRoundTripRetriesOn401(t *testing.T) {
 
 	key := storage.MakeKey(srv.URL, "client-abc")
 	cfg := &oauth.Config{
-		BaseURL: srv.URL, ClientID: "client-abc", ClientSecret: "secret-xyz",
+		BaseURL: srv.URL, ClientID: "client-abc",
 		RedirectURI: "http://127.0.0.1:8765/callback", Scopes: []string{"WRITE"},
 	}
 	// Token is unexpired, so the 401 (not expiry) is what triggers the refresh.
@@ -299,7 +298,7 @@ func TestRoundTripRetryPreservesBody(t *testing.T) {
 	defer srv.Close()
 
 	cfg := &oauth.Config{
-		BaseURL: srv.URL, ClientID: "client-abc", ClientSecret: "secret-xyz",
+		BaseURL: srv.URL, ClientID: "client-abc",
 		RedirectURI: "http://127.0.0.1:8765/callback", Scopes: []string{"WRITE"},
 	}
 	a := &OAuthAuthenticator{

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/appleboy/go-jira/pkg/oauth"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +13,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/oauth"
+	"github.com/appleboy/go-jira/pkg/storage"
 )
 
 // memStore is an in-memory Store for tests.

--- a/pkg/auth/resolver.go
+++ b/pkg/auth/resolver.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/appleboy/go-jira/pkg/oauth"
 	"github.com/appleboy/go-jira/pkg/storage"
-	"net/http"
 )
 
 // Config carries everything Resolve needs to choose an Authenticator.

--- a/pkg/auth/resolver.go
+++ b/pkg/auth/resolver.go
@@ -20,11 +20,10 @@ type Config struct {
 	OAuthRefreshToken string
 
 	// OAuth common
-	OAuthClientID     string
-	OAuthClientSecret string
-	OAuthBaseURL      string
-	OAuthRedirectURI  string
-	OAuthScopes       []string
+	OAuthClientID    string
+	OAuthBaseURL     string
+	OAuthRedirectURI string
+	OAuthScopes      []string
 
 	// OAuthHTTPClient, if set, is used for OAuth token endpoint requests
 	// (refresh / exchange) so they honour the same TLS behaviour as API calls —
@@ -76,12 +75,11 @@ func Resolve(ctx context.Context, cfg Config) (Authenticator, error) {
 // oauthConfig builds the protocol-layer config shared by both OAuth modes.
 func oauthConfig(cfg Config) *oauth.Config {
 	return &oauth.Config{
-		BaseURL:      cfg.OAuthBaseURL,
-		ClientID:     cfg.OAuthClientID,
-		ClientSecret: cfg.OAuthClientSecret,
-		RedirectURI:  cfg.OAuthRedirectURI,
-		Scopes:       cfg.OAuthScopes,
-		HTTPClient:   cfg.OAuthHTTPClient,
+		BaseURL:     cfg.OAuthBaseURL,
+		ClientID:    cfg.OAuthClientID,
+		RedirectURI: cfg.OAuthRedirectURI,
+		Scopes:      cfg.OAuthScopes,
+		HTTPClient:  cfg.OAuthHTTPClient,
 	}
 }
 
@@ -115,9 +113,6 @@ func tryResolveOAuthStorage(cfg Config) (Authenticator, bool, error) {
 func resolveOAuthEnv(ctx context.Context, cfg Config) (Authenticator, error) {
 	if cfg.OAuthClientID == "" {
 		return nil, errors.New("oauth-env: JIRA_OAUTH_CLIENT_ID is required")
-	}
-	if cfg.OAuthClientSecret == "" {
-		return nil, errors.New("oauth-env: JIRA_OAUTH_CLIENT_SECRET is required")
 	}
 	if cfg.OAuthBaseURL == "" {
 		// Without a base URL the token endpoint URL is empty and oc.Refresh would

--- a/pkg/auth/resolver_oauth_test.go
+++ b/pkg/auth/resolver_oauth_test.go
@@ -2,10 +2,11 @@ package auth
 
 import (
 	"context"
-	"github.com/appleboy/go-jira/pkg/storage"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/appleboy/go-jira/pkg/storage"
 )
 
 func TestResolveOAuthEnv(t *testing.T) {

--- a/pkg/auth/resolver_oauth_test.go
+++ b/pkg/auth/resolver_oauth_test.go
@@ -15,7 +15,6 @@ func TestResolveOAuthEnv(t *testing.T) {
 	a, err := Resolve(context.Background(), Config{
 		OAuthRefreshToken: "injected-refresh",
 		OAuthClientID:     "client-abc",
-		OAuthClientSecret: "secret-xyz",
 		OAuthBaseURL:      srv.URL,
 		OAuthScopes:       []string{"WRITE"},
 		OnRotate: func(tok *storage.StoredToken) error {
@@ -39,22 +38,10 @@ func TestResolveOAuthEnv(t *testing.T) {
 	}
 }
 
-func TestResolveOAuthEnvRequiresClientSecret(t *testing.T) {
-	_, err := Resolve(context.Background(), Config{
-		OAuthRefreshToken: "x",
-		OAuthClientID:     "client-abc",
-		OAuthBaseURL:      "https://jira.example.com",
-	})
-	if err == nil {
-		t.Fatal("expected error when client secret missing in oauth-env mode")
-	}
-}
-
 func TestResolveOAuthEnvRequiresBaseURL(t *testing.T) {
 	_, err := Resolve(context.Background(), Config{
 		OAuthRefreshToken: "x",
 		OAuthClientID:     "client-abc",
-		OAuthClientSecret: "secret",
 	})
 	if err == nil {
 		t.Fatal("expected error when base URL missing in oauth-env mode")

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -34,11 +34,10 @@ const defaultHTTPTimeout = 30 * time.Second
 
 // Config holds the settings needed to talk to a Jira DC OAuth provider.
 type Config struct {
-	BaseURL      string   // e.g. "https://jira.example.com"
-	ClientID     string   //
-	ClientSecret string   //
-	RedirectURI  string   // e.g. "http://127.0.0.1:8765/callback"
-	Scopes       []string // e.g. ["WRITE"]
+	BaseURL     string   // e.g. "https://jira.example.com"
+	ClientID    string   // public client; PKCE protects the flow, so no secret
+	RedirectURI string   // e.g. "http://127.0.0.1:8765/callback"
+	Scopes      []string // e.g. ["WRITE"]
 
 	// TLSCertFile and TLSKeyFile, when both set, make the local callback server
 	// serve HTTPS instead of plain HTTP. Jira DC matches the registered
@@ -92,16 +91,15 @@ func (c *Config) Validate() error {
 
 // oauth2Config builds the x/oauth2 configuration for this Jira instance.
 //
-// AuthStyleInParams puts client_id/client_secret in the request body params,
-// which is what the Jira DC provider expects, and avoids x/oauth2's
-// auto-detect probe request.
+// AuthStyleInParams puts client_id in the request body params, which is what
+// the Jira DC provider expects, and avoids x/oauth2's auto-detect probe
+// request. This is a public PKCE client, so no client secret is sent.
 func (c *Config) oauth2Config() *oauth2.Config {
 	// Trim a trailing slash so a base URL entered as "https://jira.example.com/"
 	// does not yield a double slash ("…com//rest/…") in the endpoint URLs.
 	base := strings.TrimRight(c.BaseURL, "/")
 	return &oauth2.Config{
-		ClientID:     c.ClientID,
-		ClientSecret: c.ClientSecret,
+		ClientID: c.ClientID,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:   base + authorizePath,
 			TokenURL:  base + tokenPath,

--- a/pkg/oauth/config_test.go
+++ b/pkg/oauth/config_test.go
@@ -12,11 +12,10 @@ import (
 // testConfig returns a Config pointed at srv with sensible defaults.
 func testConfig(baseURL string) *Config {
 	return &Config{
-		BaseURL:      baseURL,
-		ClientID:     "client-abc",
-		ClientSecret: "secret-xyz",
-		RedirectURI:  "http://127.0.0.1:8765/callback",
-		Scopes:       []string{"WRITE"},
+		BaseURL:     baseURL,
+		ClientID:    "client-abc",
+		RedirectURI: "http://127.0.0.1:8765/callback",
+		Scopes:      []string{"WRITE"},
 	}
 }
 

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -15,7 +15,9 @@ import (
 // stored secret must be rotated).
 var (
 	ErrInvalidGrant  = errors.New("oauth: invalid_grant (refresh token expired or revoked)")
-	ErrInvalidClient = errors.New("oauth: invalid_client (client_id wrong or unknown)")
+	ErrInvalidClient = errors.New(
+		"oauth: invalid_client (check client_id, or the app may be a confidential " +
+			"client that requires a secret — go-jira only supports public PKCE clients)")
 	ErrServerError   = errors.New("oauth: server error")
 )
 

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -18,7 +18,7 @@ var (
 	ErrInvalidClient = errors.New(
 		"oauth: invalid_client (check client_id, or the app may be a confidential " +
 			"client that requires a secret — go-jira only supports public PKCE clients)")
-	ErrServerError   = errors.New("oauth: server error")
+	ErrServerError = errors.New("oauth: server error")
 )
 
 // mapError translates x/oauth2's *oauth2.RetrieveError into our sentinel

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -15,7 +15,7 @@ import (
 // stored secret must be rotated).
 var (
 	ErrInvalidGrant  = errors.New("oauth: invalid_grant (refresh token expired or revoked)")
-	ErrInvalidClient = errors.New("oauth: invalid_client (client_id or client_secret wrong)")
+	ErrInvalidClient = errors.New("oauth: invalid_client (client_id wrong or unknown)")
 	ErrServerError   = errors.New("oauth: server error")
 )
 

--- a/pkg/oauth/refresh_test.go
+++ b/pkg/oauth/refresh_test.go
@@ -35,6 +35,11 @@ func TestRefreshSuccessRotatesToken(t *testing.T) {
 	if got := gotForm["refresh_token"]; len(got) != 1 || got[0] != "refresh-1-old" {
 		t.Errorf("refresh_token = %v, want [refresh-1-old]", got)
 	}
+	// The refresh path also hits the token endpoint: as a public PKCE client it
+	// must never send a client_secret, even as an empty value.
+	if got, ok := gotForm["client_secret"]; ok {
+		t.Errorf("client_secret present in refresh request = %v, want absent", got)
+	}
 }
 
 func TestRefreshInvalidGrant(t *testing.T) {

--- a/pkg/oauth/token_test.go
+++ b/pkg/oauth/token_test.go
@@ -42,6 +42,12 @@ func TestExchangeCodeSuccess(t *testing.T) {
 	if got := gotForm["client_id"]; len(got) != 1 || got[0] != "client-abc" {
 		t.Errorf("client_id = %v, want [client-abc]", got)
 	}
+	// go-jira is a public PKCE client: the token request must never carry a
+	// client_secret, even as an empty value. Guards against config wiring or
+	// x/oauth2 behavior reintroducing the parameter.
+	if got, ok := gotForm["client_secret"]; ok {
+		t.Errorf("client_secret present in token request = %v, want absent", got)
+	}
 }
 
 func TestExchangeCodeErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
Removes the OAuth client secret from go-jira entirely. The flow is a public PKCE client, so no secret is needed for interactive login or for the CI refresh-token (`oauth-env`) mode. This drops the `JIRA_OAUTH_CLIENT_SECRET` env var, the `--client-secret` flag, and the `DefaultOAuthClientSecret` build-time ldflag. The `oauth-env` CI mode and refresh-token rotation write-back are unchanged. **Breaking change.**

## AI Authorship
- [x] AI was used. Details:
  - **Tool / model**: Claude Code (Opus 4.7)
  - **AI-authored files**: all 20 files in this PR
  - **Human line-by-line reviewed**: none yet — the author has not reviewed line-by-line. Reviewers should treat the auth/oauth changes accordingly.

## Change classification
- [x] Core code (broad impact — needs line-by-line review)
  - Touches `pkg/auth` and `pkg/oauth` (authentication path) and the public config surface (env var / flag / ldflag).

## Verification
- [x] Unit tests (existing oauth/auth tests updated; the obsolete `TestResolveOAuthEnvRequiresClientSecret` removed)
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [ ] Stress / soak test: N/A
- Manual verification: confirm `go-jira login` (public PKCE client) and an `oauth-env` CI run with only `JIRA_OAUTH_CLIENT_ID` + `JIRA_OAUTH_REFRESH_TOKEN` still authenticate against a real Jira DC instance.

## Verifiability check
- [x] Refresh-token rotation behavior is unchanged and still covered by tests
- [x] Reviewer can judge correctness from the diff + auth test suite

## Security check
- [x] No secrets in code (this change *removes* a credential field)
- [x] `oauth-env` still validates client ID + base URL before refresh
- Note: this widens the public-client model — refresh now succeeds on client ID alone, the intended PKCE public-client behavior.

## Risk & rollback
- **Risk**: anyone who registered the OAuth app as a *confidential* client (one that requires a secret at the token endpoint) will break. The project treats the app as a public PKCE client, so this is expected.
- **Rollback**: revert this commit; the secret field and wiring return.

## Reviewer guide
- **Read carefully**: `pkg/auth/resolver.go` (oauth-env path), `pkg/oauth/config.go` (token request), `cmd/go-jira/run.go`
- **Spot-check OK**: docs (`README*.md`, `docs/oauth-usage.md`), `Makefile`, `.goreleaser.yaml`, `.github/workflows/example-oauth-ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
