### PR TITLE
refactor(cli): deduplicate concurrent issue processing and simplify helpers

### DIFF
--- a/cmd/go-jira/assignee.go
+++ b/cmd/go-jira/assignee.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"sync"
 
 	jira "github.com/andygrunwald/go-jira"
 )
@@ -17,52 +16,29 @@ func processAssignee(
 	issues []*jira.Issue,
 	assignee *jira.User,
 ) error {
-	var wg sync.WaitGroup
-	errChan := make(chan error, len(issues))
-
-	for _, issue := range issues {
-		wg.Add(1)
-		go func(iss *jira.Issue) {
-			defer wg.Done()
-			resp, err := jiraClient.Issue.UpdateAssigneeWithContext(
-				ctx,
-				iss.Key,
-				&jira.User{
-					Name: assignee.Name,
-				},
-			)
-			if resp != nil && resp.Body != nil {
-				defer resp.Body.Close()
-			}
-			if err != nil {
-				slog.Error("error updating assignee", "issue", iss.Key, "error", err)
-				errChan <- err
-				return
-			}
-			if resp.StatusCode != http.StatusNoContent {
-				err := fmt.Errorf("unexpected status: %s", resp.Status)
-				slog.Error("error updating assignee", "issue", iss.Key, statusKey, resp.Status)
-				errChan <- err
-				return
-			}
-			slog.Info("assignee updated",
-				"issue", iss.Key,
-				"assignee", assignee.Name,
-			)
-		}(issue)
-	}
-
-	wg.Wait()
-	close(errChan)
-
-	// Collect any errors
-	var errs []error
-	for err := range errChan {
-		errs = append(errs, err)
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("encountered %d errors while updating assignees", len(errs))
-	}
-
-	return nil
+	return forEachIssueConcurrent(issues, "updating assignees", func(iss *jira.Issue) error {
+		resp, err := jiraClient.Issue.UpdateAssigneeWithContext(
+			ctx,
+			iss.Key,
+			&jira.User{
+				Name: assignee.Name,
+			},
+		)
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+		if err != nil {
+			slog.Error("error updating assignee", "issue", iss.Key, "error", err)
+			return err
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			slog.Error("error updating assignee", "issue", iss.Key, statusKey, resp.Status)
+			return fmt.Errorf("unexpected status: %s", resp.Status)
+		}
+		slog.Info("assignee updated",
+			"issue", iss.Key,
+			"assignee", assignee.Name,
+		)
+		return nil
+	})
 }

--- a/cmd/go-jira/comment.go
+++ b/cmd/go-jira/comment.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"sync"
 
 	jira "github.com/andygrunwald/go-jira"
 )
@@ -19,63 +18,40 @@ func addComments(
 	issues []*jira.Issue,
 	user *jira.User,
 ) error {
-	var wg sync.WaitGroup
-	errChan := make(chan error, len(issues))
+	return forEachIssueConcurrent(issues, "adding comments", func(iss *jira.Issue) error {
+		item, resp, err := jiraClient.Issue.AddCommentWithContext(
+			ctx,
+			iss.Key,
+			&jira.Comment{
+				Name: user.Name,
+				Body: comment,
+			},
+		)
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+		if err != nil {
+			slog.Error("error adding comment", "issue", iss.Key, "error", err)
+			return err
+		}
 
-	for _, issue := range issues {
-		wg.Add(1)
-		go func(iss *jira.Issue) {
-			defer wg.Done()
-			item, resp, err := jiraClient.Issue.AddCommentWithContext(
-				ctx,
+		if resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			slog.Error(
+				"error adding comment",
+				"issue",
 				iss.Key,
-				&jira.Comment{
-					Name: user.Name,
-					Body: comment,
-				},
+				statusKey,
+				resp.StatusCode,
+				"body",
+				string(body),
 			)
-			if resp != nil && resp.Body != nil {
-				defer resp.Body.Close()
-			}
-			if err != nil {
-				slog.Error("error adding comment", "issue", iss.Key, "error", err)
-				errChan <- err
-				return
-			}
-
-			if resp.StatusCode != http.StatusCreated {
-				body, _ := io.ReadAll(resp.Body)
-				err := fmt.Errorf("unexpected status: %d, body: %s", resp.StatusCode, string(body))
-				slog.Error(
-					"error adding comment",
-					"issue",
-					iss.Key,
-					statusKey,
-					resp.StatusCode,
-					"body",
-					string(body),
-				)
-				errChan <- err
-				return
-			}
-			slog.Info("added comment to issue",
-				"issue", iss.Key,
-				"comment", item.Body,
-			)
-		}(issue)
-	}
-
-	wg.Wait()
-	close(errChan)
-
-	// Collect any errors
-	var errs []error
-	for err := range errChan {
-		errs = append(errs, err)
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("encountered %d errors while adding comments", len(errs))
-	}
-
-	return nil
+			return fmt.Errorf("unexpected status: %d, body: %s", resp.StatusCode, string(body))
+		}
+		slog.Info("added comment to issue",
+			"issue", iss.Key,
+			"comment", item.Body,
+		)
+		return nil
+	})
 }

--- a/cmd/go-jira/concurrent.go
+++ b/cmd/go-jira/concurrent.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	jira "github.com/andygrunwald/go-jira"
+)
+
+// forEachIssueConcurrent runs fn for every issue in parallel. fn is responsible
+// for its own logging; any error it returns is counted. When one or more issues
+// fail, a single summarizing error is returned, using noun (e.g. "adding
+// comments") to describe the operation.
+func forEachIssueConcurrent(issues []*jira.Issue, noun string, fn func(*jira.Issue) error) error {
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(issues))
+
+	for _, issue := range issues {
+		wg.Add(1)
+		go func(iss *jira.Issue) {
+			defer wg.Done()
+			if err := fn(iss); err != nil {
+				errChan <- err
+			}
+		}(issue)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	if n := len(errChan); n > 0 {
+		return fmt.Errorf("encountered %d errors while %s", n, noun)
+	}
+	return nil
+}

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -207,7 +207,7 @@ func cmdContextWithTimeout(
 // flagStringValue returns a string flag's value when the command defines it and
 // the user changed it, otherwise "".
 func flagStringValue(cmd *cobra.Command, name string) string {
-	if cmd == nil || cmd.Flags().Lookup(name) == nil || !cmd.Flags().Changed(name) {
+	if !flagChanged(cmd, name) {
 		return ""
 	}
 	v, _ := cmd.Flags().GetString(name)
@@ -250,7 +250,7 @@ func resolveCallbackPort(cmd *cobra.Command) int {
 // flagBoolValue returns a bool flag's value when the command defines it and the
 // user changed it, otherwise false.
 func flagBoolValue(cmd *cobra.Command, name string) bool {
-	if cmd == nil || cmd.Flags().Lookup(name) == nil || !cmd.Flags().Changed(name) {
+	if !flagChanged(cmd, name) {
 		return false
 	}
 	v, _ := cmd.Flags().GetBool(name)

--- a/cmd/go-jira/search.go
+++ b/cmd/go-jira/search.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -109,14 +108,7 @@ func runSearch(cmd *cobra.Command) error {
 // custom field IDs appended.
 func searchFields(fieldsArg string, config Config) []string {
 	if fieldsArg != "" {
-		parts := strings.Split(fieldsArg, ",")
-		out := make([]string, 0, len(parts))
-		for _, p := range parts {
-			if p = strings.TrimSpace(p); p != "" {
-				out = append(out, p)
-			}
-		}
-		return out
+		return splitCSV(fieldsArg)
 	}
 	fields := make([]string, 0, len(defaultSearchBaseFields)+2)
 	fields = append(fields, defaultSearchBaseFields...)

--- a/cmd/go-jira/transition.go
+++ b/cmd/go-jira/transition.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"sync"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/appleboy/com/convert"
@@ -20,78 +19,55 @@ func processTransitions(
 	resolution string,
 	issues []*jira.Issue,
 ) error {
-	var wg sync.WaitGroup
-	errChan := make(chan error, len(issues))
+	return forEachIssueConcurrent(issues, "processing transitions", func(iss *jira.Issue) error {
+		slog.Info("issue info",
+			"key", iss.Key,
+			"summary", iss.Fields.Summary,
+			"current status", iss.Fields.Status.Name,
+		)
 
-	for _, issue := range issues {
-		wg.Add(1)
-		go func(iss *jira.Issue) {
-			defer wg.Done()
-			slog.Info("issue info",
+		transitionFound := false
+		for _, transition := range iss.Transitions {
+			if !strings.EqualFold(transition.Name, toTransition) {
+				continue
+			}
+			transitionFound = true
+
+			input := &jira.TransitionPayloadInput{
+				TicketID:     iss.Key,
+				TransitionID: transition.ID,
+			}
+			if resolution != "" {
+				input.ResolutionID = convert.ToPtr(resolution)
+			}
+			resp, err := jiraClient.Issue.DoTransitionPayloadWithContext(
+				ctx,
+				input,
+			)
+			if resp != nil && resp.Body != nil {
+				defer resp.Body.Close()
+			}
+			if err != nil {
+				slog.Error("error moving issue", "issue", iss.Key, "error", err)
+				return err
+			}
+			if resp.StatusCode != http.StatusNoContent {
+				slog.Error("error moving issue", "issue", iss.Key, statusKey, resp.Status)
+				return fmt.Errorf("unexpected status: %s", resp.Status)
+			}
+			slog.Info("issue moved to transition",
 				"key", iss.Key,
 				"summary", iss.Fields.Summary,
-				"current status", iss.Fields.Status.Name,
+				"transition", transition.Name,
 			)
+		}
 
-			transitionFound := false
-			for _, transition := range iss.Transitions {
-				if !strings.EqualFold(transition.Name, toTransition) {
-					continue
-				}
-				transitionFound = true
-
-				input := &jira.TransitionPayloadInput{
-					TicketID:     iss.Key,
-					TransitionID: transition.ID,
-				}
-				if resolution != "" {
-					input.ResolutionID = convert.ToPtr(resolution)
-				}
-				resp, err := jiraClient.Issue.DoTransitionPayloadWithContext(
-					ctx,
-					input,
-				)
-				if resp != nil && resp.Body != nil {
-					defer resp.Body.Close()
-				}
-				if err != nil {
-					slog.Error("error moving issue", "issue", iss.Key, "error", err)
-					errChan <- err
-					return
-				}
-				if resp.StatusCode != http.StatusNoContent {
-					err := fmt.Errorf("unexpected status: %s", resp.Status)
-					slog.Error("error moving issue", "issue", iss.Key, statusKey, resp.Status)
-					errChan <- err
-					return
-				}
-				slog.Info("issue moved to transition",
-					"key", iss.Key,
-					"summary", iss.Fields.Summary,
-					"transition", transition.Name,
-				)
-			}
-
-			if !transitionFound {
-				slog.Warn("transition not found for issue",
-					"issue", iss.Key,
-					"transition", toTransition,
-				)
-			}
-		}(issue)
-	}
-
-	wg.Wait()
-	close(errChan)
-
-	// Collect any errors
-	var errs []error
-	for err := range errChan {
-		errs = append(errs, err)
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("encountered %d errors while processing transitions", len(errs))
-	}
-
-	return nil
+		if !transitionFound {
+			slog.Warn("transition not found for issue",
+				"issue", iss.Key,
+				"transition", toTransition,
+			)
+		}
+		return nil
+	})
 }

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -10,10 +10,9 @@ import (
 )
 
 type JiraRenderer struct {
-	builder     strings.Builder
-	inList      bool
-	listDepth   int
-	inCodeBlock bool
+	builder   strings.Builder
+	inList    bool
+	listDepth int
 }
 
 func NewJiraRenderer() *JiraRenderer {
@@ -152,7 +151,7 @@ func (r *JiraRenderer) renderItem(w *bytes.Buffer, _ *bf.Node, entering bool) {
 		return
 	}
 	indent := strings.Repeat("*", r.listDepth)
-	if w.Len() > 0 && !strings.HasSuffix(w.String(), "\n") {
+	if b := w.Bytes(); len(b) > 0 && b[len(b)-1] != '\n' {
 		w.WriteString("\n")
 	}
 	w.WriteString(indent + " ")
@@ -166,7 +165,6 @@ func (r *JiraRenderer) renderCode(w *bytes.Buffer, node *bf.Node, _ bool) {
 
 func (r *JiraRenderer) renderCodeBlock(w *bytes.Buffer, node *bf.Node, entering bool) {
 	if entering {
-		r.inCodeBlock = true
 		language := string(node.Info)
 		if language == "" {
 			language = "java"
@@ -180,7 +178,6 @@ func (r *JiraRenderer) renderCodeBlock(w *bytes.Buffer, node *bf.Node, entering 
 		w.Write(node.Literal)
 		w.WriteString("{code}")
 	}
-	r.inCodeBlock = false
 }
 
 func (r *JiraRenderer) renderHardbreak(w *bytes.Buffer, _ *bf.Node, _ bool) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -43,5 +43,5 @@ func GetGlobalValue(key string) string {
 //
 //	bool - the boolean representation of the input string.
 func ToBool(s string) bool {
-	return strings.ToLower(s) == "true" || s == "1"
+	return s == "1" || strings.ToLower(s) == "true"
 }


### PR DESCRIPTION
## Summary

Pure-refactor cleanup pass on the CLI: removes duplicated concurrency boilerplate and a handful of small redundancies surfaced by a `/simplify` review. No behavior change — net **−48 lines** (148 added, 196 removed).

- Extract the shared "spawn a goroutine per issue, collect errors, summarize" scaffold (duplicated three times) into a single `forEachIssueConcurrent` helper.
- Reuse existing helpers instead of re-implementing them (`flagChanged`, `splitCSV`).
- Drop dead state and a needless allocation in the Jira markdown renderer.

## AI Authorship
- [x] AI was used. Details:
  - **Tool / model**: Claude Code (Opus 4.8)
  - **AI-authored files**: all changed files (`cmd/go-jira/concurrent.go`, `assignee.go`, `comment.go`, `transition.go`, `config.go`, `search.go`, `pkg/markdown/markdown.go`, `pkg/util/util.go`)
  - **Human line-by-line reviewed**: pending author review

## Change classification
- [x] Leaf node (local impact) — command-layer wiring and small pure helpers; no shared schema, auth, or public API touched. The one cross-cutting addition (`forEachIssueConcurrent`) is internal to `cmd/go-jira` and used only by the three batch commands.

## What changed

- **Concurrency dedup** — `assignee.go`, `comment.go`, and `transition.go` each hand-rolled the identical `sync.WaitGroup` + buffered error-channel + collect-and-summarize pattern. Extracted into `cmd/go-jira/concurrent.go::forEachIssueConcurrent(issues, noun, fn)`; each command now supplies only its per-issue body and returns the error directly. ~80 lines of boilerplate removed; the concurrency logic now lives in one place.
- **`config.go`** — `flagStringValue` / `flagBoolValue` inlined the guard `cmd == nil || Lookup == nil || !Changed`, which is exactly the existing `flagChanged` helper; replaced with `!flagChanged(cmd, name)`.
- **`search.go`** — `searchFields` re-implemented the trim/skip-empty CSV split; now calls the existing `splitCSV`. Removed the now-unused `strings` import.
- **`pkg/markdown/markdown.go`** — removed the `inCodeBlock` field (written, never read); replaced `strings.HasSuffix(w.String(), "\n")` (copies the whole buffer to a string on every list item) with a direct last-byte check on `w.Bytes()`.
- **`pkg/util/util.go`** — `ToBool` reordered to `s == "1" || strings.ToLower(s) == "true"` so the numeric form short-circuits before allocating a lowercased copy.

## Verification
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass (no test changes needed; existing tests cover the refactored paths)
- Manual verification: behavior of `assignee`, `comment`, `transition`, `search`, and markdown conversion is unchanged — same log output, same error messages (`encountered N errors while …`), same field selection.

## Risk & rollback
- **Risk**: Low. The only semantic-adjacent change is that each batch command now returns its per-issue error instead of pushing to a channel inline; the aggregate error string and count are preserved. Worst case would be a subtly different error-summary, covered by existing tests.
- **Rollback**: revert the single commit `refactor(cli): deduplicate concurrent issue processing and simplify helpers`.

## Reviewer guide
- **Read carefully**: `cmd/go-jira/concurrent.go` (new shared helper) and the three call sites (`assignee.go`, `comment.go`, `transition.go`) — confirm the per-issue early-return maps cleanly onto the old `errChan <- err; return`.
- **Spot-check OK**: `config.go`, `search.go`, `pkg/markdown/markdown.go`, `pkg/util/util.go` — mechanical reuse / dead-code removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
