### PR TITLE
fix: correct markdown conversion and CLI command bugs

### DIFF
--- a/cmd/go-jira/concurrent.go
+++ b/cmd/go-jira/concurrent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -28,8 +29,16 @@ func forEachIssueConcurrent(issues []*jira.Issue, noun string, fn func(*jira.Iss
 	wg.Wait()
 	close(errChan)
 
-	if n := len(errChan); n > 0 {
-		return fmt.Errorf("encountered %d errors while %s", n, noun)
+	// Collect the actual errors, not just a count, so the real cause (HTTP
+	// status, message) survives into the returned/serialized error instead of
+	// only reaching the per-issue logs.
+	var errs []error
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("encountered %d errors while %s: %w",
+			len(errs), noun, errors.Join(errs...))
 	}
 	return nil
 }

--- a/cmd/go-jira/get.go
+++ b/cmd/go-jira/get.go
@@ -61,14 +61,7 @@ func runGet(cmd *cobra.Command) error {
 	}
 
 	return emitResult(config, issue, func() {
-		status := ""
-		if issue.Fields != nil && issue.Fields.Status != nil {
-			status = issue.Fields.Status.Name
-		}
-		summary := ""
-		if issue.Fields != nil {
-			summary = issue.Fields.Summary
-		}
-		fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", issue.Key, status, summary)
+		fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n",
+			issue.Key, issueStatusName(issue), issueSummary(issue))
 	})
 }

--- a/cmd/go-jira/issue.go
+++ b/cmd/go-jira/issue.go
@@ -106,3 +106,21 @@ func getIssueKeys(ref, issuePattern string) ([]string, error) {
 	}
 	return issueKeys, nil
 }
+
+// issueSummary returns the issue summary, tolerating a nil Fields — a partial
+// issue response (e.g. field-level security) can leave it unset.
+func issueSummary(iss *jira.Issue) string {
+	if iss.Fields == nil {
+		return ""
+	}
+	return iss.Fields.Summary
+}
+
+// issueStatusName returns the issue status name, tolerating nil Fields/Status
+// (both are pointers with omitempty in a partial response).
+func issueStatusName(iss *jira.Issue) string {
+	if iss.Fields == nil || iss.Fields.Status == nil {
+		return ""
+	}
+	return iss.Fields.Status.Name
+}

--- a/cmd/go-jira/run.go
+++ b/cmd/go-jira/run.go
@@ -143,10 +143,18 @@ func run(cmd *cobra.Command) error {
 	}
 
 	if config.resolution != "" {
-		config.resolution, err = getResolutionID(ctx, jiraClient, config.resolution)
+		var resolutionID string
+		resolutionID, err = getResolutionID(ctx, jiraClient, config.resolution)
 		if err != nil {
 			return fmt.Errorf("error getting resolution: %w", err)
 		}
+		// getResolutionID returns ("", nil) when no resolution matches; without
+		// this guard a typo'd --resolution would silently transition the issue
+		// with no resolution set and still report success.
+		if resolutionID == "" {
+			return fmt.Errorf("resolution %q not found", config.resolution)
+		}
+		config.resolution = resolutionID
 	}
 
 	if config.toTransition != "" {

--- a/cmd/go-jira/search.go
+++ b/cmd/go-jira/search.go
@@ -89,16 +89,10 @@ func runSearch(cmd *cobra.Command) error {
 	}
 
 	return emitResult(config, issues, func() {
-		for _, issue := range issues {
-			status := ""
-			if issue.Fields != nil && issue.Fields.Status != nil {
-				status = issue.Fields.Status.Name
-			}
-			summary := ""
-			if issue.Fields != nil {
-				summary = issue.Fields.Summary
-			}
-			fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", issue.Key, status, summary)
+		for i := range issues {
+			issue := &issues[i]
+			fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n",
+				issue.Key, issueStatusName(issue), issueSummary(issue))
 		}
 	})
 }

--- a/cmd/go-jira/transition.go
+++ b/cmd/go-jira/transition.go
@@ -20,10 +20,14 @@ func processTransitions(
 	issues []*jira.Issue,
 ) error {
 	return forEachIssueConcurrent(issues, "processing transitions", func(iss *jira.Issue) error {
+		// Use the nil-safe accessors: a partial issue response can leave Fields
+		// or Status nil, and a deref here would panic inside the worker
+		// goroutine and take down the whole process.
+		summary := issueSummary(iss)
 		slog.Info("issue info",
 			"key", iss.Key,
-			"summary", iss.Fields.Summary,
-			"current status", iss.Fields.Status.Name,
+			"summary", summary,
+			"current status", issueStatusName(iss),
 		)
 
 		transitionFound := false
@@ -57,9 +61,12 @@ func processTransitions(
 			}
 			slog.Info("issue moved to transition",
 				"key", iss.Key,
-				"summary", iss.Fields.Summary,
+				"summary", summary,
 				"transition", transition.Name,
 			)
+			// The issue has moved; stop scanning so a second transition with the
+			// same name isn't attempted against the already-transitioned issue.
+			break
 		}
 
 		if !transitionFound {

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -10,9 +10,11 @@ import (
 )
 
 type JiraRenderer struct {
-	builder   strings.Builder
-	inList    bool
-	listDepth int
+	builder strings.Builder
+	// listOrdered tracks the ordered-ness of each currently open list level so
+	// nested lists pick the right Jira marker ('#' ordered, '*' bullet). Its
+	// length is the current nesting depth, and len > 0 means "inside a list".
+	listOrdered []bool
 }
 
 func NewJiraRenderer() *JiraRenderer {
@@ -29,6 +31,11 @@ func (r *JiraRenderer) RenderNode(w *bytes.Buffer, node *bf.Node, entering bool)
 		r.renderHorizontalRule(w, node, entering)
 	case bf.Image:
 		r.renderImage(w, node, entering)
+		// Skip the image's child nodes (the alt text): Jira image markup is
+		// `!url!` with no display-text slot, so rendering the alt corrupts it.
+		if entering {
+			return bf.SkipChildren
+		}
 	case bf.HTMLBlock, bf.HTMLSpan:
 		// Ignore HTML blocks and spans
 	case bf.Softbreak:
@@ -74,11 +81,13 @@ func (r *JiraRenderer) renderHorizontalRule(w *bytes.Buffer, _ *bf.Node, _ bool)
 }
 
 func (r *JiraRenderer) renderImage(w *bytes.Buffer, node *bf.Node, entering bool) {
-	if entering {
-		w.WriteString("!")
+	// Jira embeds images as `!url!`; the part after a `|` is reserved for
+	// attributes (width, align, thumbnail), not alt text. The alt-text child is
+	// skipped by RenderNode, so the whole token is emitted on entering.
+	if !entering {
 		return
 	}
-	w.WriteString("|")
+	w.WriteString("!")
 	w.Write(node.Destination)
 	w.WriteString("!")
 }
@@ -88,7 +97,7 @@ func (r *JiraRenderer) renderSoftbreak(w *bytes.Buffer, _ *bf.Node, _ bool) {
 }
 
 func (r *JiraRenderer) renderParagraph(w *bytes.Buffer, _ *bf.Node, entering bool) {
-	if entering && !r.inList && w.Len() > 0 {
+	if entering && len(r.listOrdered) == 0 && w.Len() > 0 {
 		w.WriteString("\n")
 		return
 	}
@@ -133,15 +142,15 @@ func (r *JiraRenderer) renderLink(w *bytes.Buffer, node *bf.Node, entering bool)
 	w.WriteString("]")
 }
 
-func (r *JiraRenderer) renderList(w *bytes.Buffer, _ *bf.Node, entering bool) {
+func (r *JiraRenderer) renderList(w *bytes.Buffer, node *bf.Node, entering bool) {
 	if entering {
-		r.inList = true
-		r.listDepth++
+		r.listOrdered = append(r.listOrdered, node.ListFlags&bf.ListTypeOrdered != 0)
 		return
 	}
-	r.listDepth--
-	if r.listDepth == 0 {
-		r.inList = false
+	if n := len(r.listOrdered); n > 0 {
+		r.listOrdered = r.listOrdered[:n-1]
+	}
+	if len(r.listOrdered) == 0 {
 		w.WriteString("\n")
 	}
 }
@@ -150,11 +159,21 @@ func (r *JiraRenderer) renderItem(w *bytes.Buffer, _ *bf.Node, entering bool) {
 	if !entering {
 		return
 	}
-	indent := strings.Repeat("*", r.listDepth)
+	// One marker per open level, e.g. a bullet nested under an ordered list is
+	// "*#". Jira uses '#' for ordered items and '*' for bullets.
+	indent := make([]byte, len(r.listOrdered))
+	for i, ordered := range r.listOrdered {
+		if ordered {
+			indent[i] = '#'
+		} else {
+			indent[i] = '*'
+		}
+	}
 	if b := w.Bytes(); len(b) > 0 && b[len(b)-1] != '\n' {
 		w.WriteString("\n")
 	}
-	w.WriteString(indent + " ")
+	w.Write(indent)
+	w.WriteString(" ")
 }
 
 func (r *JiraRenderer) renderCode(w *bytes.Buffer, node *bf.Node, _ bool) {
@@ -199,7 +218,10 @@ func (r *JiraRenderer) convertMentions(text string) string {
 	r.builder.Reset()
 	r.builder.Grow(length + count*2) // Preallocate buffer with an initial capacity
 	for i := 0; i < length; i++ {
-		if text[i] == '@' && i+1 < length && isValidMentionChar(text[i+1]) {
+		// Require a left boundary so an '@' embedded in a word (e.g. an email
+		// address such as user@example.com) is not mistaken for a mention.
+		if text[i] == '@' && (i == 0 || !isValidMentionChar(text[i-1])) &&
+			i+1 < length && isValidMentionChar(text[i+1]) {
 			r.builder.WriteString("[~")
 			i++
 			for i < length && isValidMentionChar(text[i]) {

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -80,6 +80,21 @@ func TestMarkdownToJira(t *testing.T) {
 			markdown: "* item 1\n* item 2",
 			want:     "* item 1\n* item 2",
 		},
+		{
+			name:     "ordered list",
+			markdown: "1. first\n2. second\n3. third",
+			want:     "# first\n# second\n# third",
+		},
+		{
+			name:     "ordered list nested under bullet",
+			markdown: "* a\n  1. one\n  2. two",
+			want:     "* a\n*# one\n*# two",
+		},
+		{
+			name:     "image",
+			markdown: "![alt text](http://example.com/a.png)",
+			want:     "!http://example.com/a.png!",
+		},
 	}
 
 	for _, tt := range tests {
@@ -148,6 +163,16 @@ func TestConvertMentions(t *testing.T) {
 			name: "mention with special characters",
 			text: "Hello @user!@name",
 			want: "Hello [~user]![~name]",
+		},
+		{
+			name: "email address is not a mention",
+			text: "email me at user@example.com please",
+			want: "email me at user@example.com please",
+		},
+		{
+			name: "mention after non-word boundary still converts",
+			text: "(@user)",
+			want: "([~user])",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes a set of correctness bugs surfaced by a full-codebase review, plus a small refactor. The Markdown→Jira converter now handles ordered lists, images, and email-like text correctly; the `run` transition path no longer panics on partial issue responses, no longer silently drops a mistyped `--resolution`, and preserves the real error detail when concurrent operations fail.

## AI Authorship
- [ ] No AI was used in this PR
- [x] AI was used. Details:
  - **Tool / model**: Claude Opus 4.8 via Claude Code (`/code-review --fix` + `/simplify`)
  - **AI-authored files**: all 8 changed files (`pkg/markdown/markdown.go`, `pkg/markdown/markdown_test.go`, `cmd/go-jira/{transition,run,concurrent,issue,get,search}.go`)
  - **Human line-by-line reviewed**: ⚠️ **None yet** — relying on the automated review pass and the green test suite. A human line-by-line review is still recommended before merge, especially the markdown renderer and `transition.go`.

## Change classification
- [x] Core code (broad impact — needs line-by-line review)
  - `concurrent.go` is shared by the transition/comment/assignee paths; the new `issueSummary`/`issueStatusName` accessors are used by 3 commands; the Markdown converter feeds `run --markdown` and `create`. Not auth/payments/schema, but CLI-internal shared infrastructure.

## What changed (by mechanism)
- **Ordered lists** — `renderItem` always emitted `*`; now tracks each open list's type and emits `#` for ordered items (and mixed nesting like `*#`).
- **Images** — `renderImage` produced `!alt|url!` (Jira reads `alt` as the filename); now emits `!url!` and skips the alt-text child via `bf.SkipChildren`.
- **Mentions** — `convertMentions` rewrote any `@` mid-word; added a left word-boundary check so `user@example.com` is left intact.
- **Nil-panic** — `processTransitions` dereferenced `iss.Fields.Status.Name` with no guard; a partial response would panic inside a worker goroutine and crash the process. Now uses nil-safe accessors.
- **Silent resolution drop** — a mistyped `--resolution` made `getResolutionID` return `("", nil)`, transitioning with no resolution and exit 0. Now errors `resolution %q not found`.
- **Lost error detail** — `forEachIssueConcurrent` returned only a count; now joins the underlying errors via `errors.Join`.
- **Refactor** — extracted shared nil-safe `issueSummary`/`issueStatusName` accessors (de-duplicating 3 inline copies) and removed a derivable `inList` field from the renderer.

## Verification
- [x] Unit tests — added 5 markdown cases (ordered list, mixed nesting, image, email-not-mention, boundary mention)
- [x] Existing integration/`run`/`transition` tests still pass
- [ ] Stress / soak test: N/A
- **Commands run**: `go build ./...`, `go vet ./...`, `gofmt -l`, `go test -race ./...` — all green.
- One reviewed finding was deliberately **not changed**: `processIssues` returning `(empty, nil)` when all lookups fail is intended/tested graceful degradation (`TestProcessIssues/context_timeout`, `TestRun/issue_retrieval_error`).

## Risk & rollback
- **Risk**: Markdown output format changes for ordered lists and images — downstream consumers expecting the old (buggy) `!alt|url!` / bulleted-ordered output would see different text. The transition `break` changes behavior only for issues with duplicate same-named transitions.
- **Rollback**: revert this commit; no migrations or state changes involved.

## Reviewer guide
- **Read carefully**: `pkg/markdown/markdown.go` (list/image/mention rendering), `cmd/go-jira/transition.go` (nil guards + early `break`).
- **Spot-check OK**: `get.go`/`search.go`/`issue.go` (mechanical swap to the shared accessors), `run.go` and `concurrent.go` (small, localized).
