### PR TITLE
feat(oauth): add token refresh broker for confidential clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - [Data subcommands](#data-subcommands)
   - [Schema introspection (for agents)](#schema-introspection-for-agents)
   - [OAuth 2.0](#oauth-20)
+    - [Token refresh broker (confidential clients)](#token-refresh-broker-confidential-clients)
 
 ## Motivation
 
@@ -251,13 +252,13 @@ summary; errors go to stderr with a non-zero exit code (see below).
 Every command exits with a distinct code per error class so scripts and agents
 can branch without parsing stderr:
 
-| Code | Meaning                                                   |
-| ---- | --------------------------------------------------------- |
-| `0`  | success                                                   |
-| `1`  | generic runtime error                                     |
-| `2`  | usage error (bad flags or arguments)                      |
-| `3`  | authentication/authorization failure (HTTP `401`/`403`)   |
-| `4`  | rate limited (HTTP `429`)                                 |
+| Code | Meaning                                                 |
+| ---- | ------------------------------------------------------- |
+| `0`  | success                                                 |
+| `1`  | generic runtime error                                   |
+| `2`  | usage error (bad flags or arguments)                    |
+| `3`  | authentication/authorization failure (HTTP `401`/`403`) |
+| `4`  | rate limited (HTTP `429`)                               |
 
 On failure a single structured JSON object is written to **stderr**. Rate-limit
 and auth failures include the HTTP status, and rate-limit failures surface the
@@ -386,10 +387,26 @@ Subcommands:
 - `go-jira logout` — remove the stored token for a site.
 - `go-jira whoami` — show the authenticated user and active auth mode.
 - `go-jira token status|refresh|print` — inspect or refresh the stored token.
+- `go-jira broker serve` — run the token refresh broker for confidential clients
+  (holds the `client_secret` server-side; see below).
 - `go-jira config show` — show resolved config and where each value came from.
 
+### Token refresh broker (confidential clients)
+
+When the Jira OAuth app is a **confidential client** (its token endpoint requires
+`client_secret` on refresh), the secret must never ship in the binary. Set
+`JIRA_TOKEN_BROKER_URL` and go-jira routes **only the refresh step** through a
+server-side broker (`go-jira broker serve`) that holds the secret and returns the
+rotated token pair. **Login is unchanged** (direct public PKCE), and with the env
+var unset behaviour is identical to today (direct refresh). The broker stores no
+tokens, coalesces concurrent refreshes of the same token into one upstream call,
+and reads the secret only from its environment (e.g. a Kubernetes Secret sourced
+from Vault). See the broker section in the guide for k8s + Vault deployment, the
+env contract, and the security model.
+
 See **[docs/oauth-usage.md](docs/oauth-usage.md)** for full setup: registering
-the client in Jira, scopes, storage backends, and CI/CD refresh-token rotation.
+the client in Jira, scopes, storage backends, CI/CD refresh-token rotation, and
+the token refresh broker.
 
 [5]: https://developer.atlassian.com/cloud/jira/platform/
 [6]: https://developer.atlassian.com/server/jira/platform/

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -37,6 +37,7 @@
   - [可组合性（管道、安静、颜色）](#可组合性管道安静颜色)
   - [Schema 自我描述（供代理程序使用）](#schema-自我描述供代理程序使用)
   - [OAuth 2.0](#oauth-20)
+    - [Token refresh broker（confidential client）](#token-refresh-brokerconfidential-client)
 
 ## 动机
 
@@ -240,8 +241,20 @@ go-jira schema --output text
 
 go-jira 通过 Authorization Code + PKCE 流程支持 Jira Data Center 的 OAuth 2.0
 provider，支持本地交互式登录与 CI/CD refresh token 注入。子命令包括
-`login` / `logout` / `whoami` / `token` / `config show`。完整配置（在 Jira
-注册 client、scope、token 存储后端、CI/CD refresh token 轮换）见
+`login` / `logout` / `whoami` / `token` / `broker serve` / `config show`。完整配置
+（在 Jira 注册 client、scope、token 存储后端、CI/CD refresh token 轮换）见
+**[docs/oauth-usage.md](docs/oauth-usage.md)**。
+
+### Token refresh broker（confidential client）
+
+当 Jira OAuth 应用是 **confidential client**（token endpoint 在 refresh 时强制要求
+`client_secret`）时,secret 绝不能编进发布的 binary。设定 `JIRA_TOKEN_BROKER_URL`
+后,go-jira 会**只**把 refresh 这一步经过一台 server 端 broker(`go-jira broker
+serve`)——broker 持有 secret、补上后向 Jira 换取轮替后的 token pair 回传给 CLI。
+**login 完全不变**(仍是直连 public PKCE);未设该环境变数时行为与现在完全相同
+(直连 refresh)。broker 不储存任何 token,会把同一颗 refresh token 的并发请求收敛成
+一次 upstream 呼叫,且 secret 只从其执行环境读取(例如来源为 Vault 的 Kubernetes
+Secret)。k8s + Vault 部署、env 契约与安全模型见
 **[docs/oauth-usage.md](docs/oauth-usage.md)**。
 
 [5]: https://developer.atlassian.com/cloud/jira/platform/

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -248,13 +248,13 @@ provider，支持本地交互式登录与 CI/CD refresh token 注入。子命令
 ### Token refresh broker（confidential client）
 
 当 Jira OAuth 应用是 **confidential client**（token endpoint 在 refresh 时强制要求
-`client_secret`）时,secret 绝不能编进发布的 binary。设定 `JIRA_TOKEN_BROKER_URL`
-后,go-jira 会**只**把 refresh 这一步经过一台 server 端 broker(`go-jira broker
-serve`)——broker 持有 secret、补上后向 Jira 换取轮替后的 token pair 回传给 CLI。
-**login 完全不变**(仍是直连 public PKCE);未设该环境变数时行为与现在完全相同
-(直连 refresh)。broker 不储存任何 token,会把同一颗 refresh token 的并发请求收敛成
-一次 upstream 呼叫,且 secret 只从其执行环境读取(例如来源为 Vault 的 Kubernetes
-Secret)。k8s + Vault 部署、env 契约与安全模型见
+`client_secret`）时，secret 绝不能编进发布的 binary。设定 `JIRA_TOKEN_BROKER_URL`
+后，go-jira 会**只**把 refresh 这一步经过一台 server 端 broker（`go-jira broker
+serve`）——broker 持有 secret、补上后向 Jira 换取轮替后的 token pair 回传给 CLI。
+**login 完全不变**（仍是直连 public PKCE）；未设该环境变数时行为与现在完全相同
+（直连 refresh）。broker 不会将 token 持久化保存，会把同一颗 refresh token 的并发请求收敛成
+一次 upstream 呼叫，且 secret 只从其执行环境读取（例如来源为 Vault 的 Kubernetes
+Secret）。k8s + Vault 部署、env 契约与安全模型见
 **[docs/oauth-usage.md](docs/oauth-usage.md)**。
 
 [5]: https://developer.atlassian.com/cloud/jira/platform/

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -248,13 +248,13 @@ provider，本機互動式登入與 CI/CD refresh token 注入皆可。子命令
 ### Token refresh broker（confidential client）
 
 當 Jira OAuth 應用是 **confidential client**（token endpoint 在 refresh 時強制要求
-`client_secret`）時,secret 絕不能編進發佈的 binary。設定 `JIRA_TOKEN_BROKER_URL`
-後,go-jira 會**只**把 refresh 這一步經過一台 server 端 broker(`go-jira broker
-serve`)——broker 持有 secret、補上後向 Jira 換取輪替後的 token pair 回傳給 CLI。
-**login 完全不變**(仍是直連 public PKCE);未設該環境變數時行為與現在完全相同
-(直連 refresh)。broker 不儲存任何 token,會把同一顆 refresh token 的並發請求收斂成
-一次 upstream 呼叫,且 secret 只從其執行環境讀取(例如來源為 Vault 的 Kubernetes
-Secret)。k8s + Vault 部署、env 契約與安全模型見
+`client_secret`）時，secret 絕不能編進發佈的 binary。設定 `JIRA_TOKEN_BROKER_URL`
+後，go-jira 會**只**把 refresh 這一步經過一台 server 端 broker（`go-jira broker
+serve`）——broker 持有 secret、補上後向 Jira 換取輪替後的 token pair 回傳給 CLI。
+**login 完全不變**（仍是直連 public PKCE）；未設該環境變數時行為與現在完全相同
+（直連 refresh）。broker 不會將 token 持久化保存，會把同一顆 refresh token 的並發請求收斂成
+一次 upstream 呼叫，且 secret 只從其執行環境讀取（例如來源為 Vault 的 Kubernetes
+Secret）。k8s + Vault 部署、env 契約與安全模型見
 **[docs/oauth-usage.md](docs/oauth-usage.md)**。
 
 [5]: https://developer.atlassian.com/cloud/jira/platform/

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -37,6 +37,7 @@
   - [可組合性（管線、安靜、顏色）](#可組合性管線安靜顏色)
   - [Schema 自我描述（供代理程式使用）](#schema-自我描述供代理程式使用)
   - [OAuth 2.0](#oauth-20)
+    - [Token refresh broker（confidential client）](#token-refresh-brokerconfidential-client)
 
 ## 動機
 
@@ -240,8 +241,20 @@ go-jira schema --output text
 
 go-jira 透過 Authorization Code + PKCE 流程支援 Jira Data Center 的 OAuth 2.0
 provider，本機互動式登入與 CI/CD refresh token 注入皆可。子命令包括
-`login` / `logout` / `whoami` / `token` / `config show`。完整設定（在 Jira
-註冊 client、scope、token 儲存後端、CI/CD refresh token 輪換）見
+`login` / `logout` / `whoami` / `token` / `broker serve` / `config show`。完整設定
+（在 Jira 註冊 client、scope、token 儲存後端、CI/CD refresh token 輪換）見
+**[docs/oauth-usage.md](docs/oauth-usage.md)**。
+
+### Token refresh broker（confidential client）
+
+當 Jira OAuth 應用是 **confidential client**（token endpoint 在 refresh 時強制要求
+`client_secret`）時,secret 絕不能編進發佈的 binary。設定 `JIRA_TOKEN_BROKER_URL`
+後,go-jira 會**只**把 refresh 這一步經過一台 server 端 broker(`go-jira broker
+serve`)——broker 持有 secret、補上後向 Jira 換取輪替後的 token pair 回傳給 CLI。
+**login 完全不變**(仍是直連 public PKCE);未設該環境變數時行為與現在完全相同
+(直連 refresh)。broker 不儲存任何 token,會把同一顆 refresh token 的並發請求收斂成
+一次 upstream 呼叫,且 secret 只從其執行環境讀取(例如來源為 Vault 的 Kubernetes
+Secret)。k8s + Vault 部署、env 契約與安全模型見
 **[docs/oauth-usage.md](docs/oauth-usage.md)**。
 
 [5]: https://developer.atlassian.com/cloud/jira/platform/

--- a/cmd/go-jira/broker.go
+++ b/cmd/go-jira/broker.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/appleboy/go-jira/pkg/broker"
+	"github.com/appleboy/go-jira/pkg/oauth"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+// brokerReadHeaderTimeout bounds how long the broker waits for request headers,
+// guarding against slow-loris clients on the (internal) listener.
+const brokerReadHeaderTimeout = 10 * time.Second
+
+// brokerShutdownTimeout bounds graceful shutdown after a termination signal.
+const brokerShutdownTimeout = 10 * time.Second
+
+// newBrokerCmd builds the `broker` command group. Today it has one subcommand,
+// `serve`, which runs the token refresh broker: a server-side service that holds
+// the confidential client_secret and performs the secret-bearing refresh on a
+// client's behalf. The secret is read ONLY from the environment, never a flag.
+func newBrokerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "broker",
+		Short:   "Run the OAuth token refresh broker (holds the client secret server-side)",
+		GroupID: groupAuth,
+		Long: `Run the OAuth token refresh broker.
+
+MediaTek's Jira DC OAuth app is a confidential client: its token endpoint
+requires the client_secret on the refresh step. go-jira ships as a public PKCE
+client and must never embed that secret. The broker is a small server-side
+service that holds the client_secret (injected from the environment, e.g. a
+Kubernetes Secret sourced from Vault) and performs only the secret-bearing
+refresh on a client's behalf. Clients set JIRA_TOKEN_BROKER_URL and send their
+refresh_token; the broker adds the secret and returns the rotated token pair.
+
+The broker stores no tokens; it keeps only a short-TTL in-memory cache that
+coalesces concurrent refreshes of the same refresh_token into one upstream call
+(handling Jira DC's refresh-token rotation race).`,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newBrokerServeCmd())
+	return cmd
+}
+
+func newBrokerServeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the token refresh broker HTTP server",
+		Long: `Start the token refresh broker HTTP server.
+
+Required environment (fail-fast if missing):
+  JIRA_BASE_URL             Jira DC base URL
+  JIRA_OAUTH_CLIENT_ID      OAuth client ID
+  JIRA_OAUTH_CLIENT_SECRET  confidential client secret (read ONLY from env)
+
+Optional:
+  JIRA_BROKER_TOKEN         caller bearer token; enforced only when set
+  JIRA_BROKER_LISTEN        listen address (default ` + defaultBrokerListen + `)
+  JIRA_BROKER_TLS_CERT/KEY  serve HTTPS directly (else terminate TLS at ingress)
+
+Endpoints: POST /v1/refresh, GET /healthz, GET /readyz.`,
+		Example: `  # Run the broker (secret comes from the environment)
+  JIRA_BASE_URL=https://jira.example.com \
+  JIRA_OAUTH_CLIENT_ID=my-client \
+  JIRA_OAUTH_CLIENT_SECRET=… \
+  go-jira broker serve --listen :8080`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBrokerServe(cmd)
+		},
+	}
+	// base-url / insecure / client-id come from the common + a single client-id
+	// flag (env still wins). The secret and caller token are env-only.
+	addCommonFlags(cmd)
+	cmd.Flags().String(flagClientID, "", "OAuth client ID (env: "+envOAuthClientID+")")
+	cmd.Flags().String(flagListen, defaultBrokerListen,
+		"Listen address (env: "+envBrokerListen+")")
+	cmd.Flags().String(flagTLSCert, "",
+		"TLS cert file to serve HTTPS directly (env: "+envBrokerTLSCert+
+			"); requires --"+flagTLSKey)
+	cmd.Flags().String(flagTLSKey, "",
+		"TLS key file to serve HTTPS directly (env: "+envBrokerTLSKey+
+			"); requires --"+flagTLSCert)
+	return cmd
+}
+
+func runBrokerServe(cmd *cobra.Command) error {
+	if err := loadEnvFromCmd(cmd); err != nil {
+		return err
+	}
+	config := loadConfig(cmd)
+
+	// Fail-fast on the required configuration so a misconfigured broker never
+	// starts and silently fails every refresh.
+	if err := requireBaseURL(config); err != nil {
+		return err
+	}
+	if config.oauthClientID == "" {
+		return errors.New("broker: OAuth client ID required: set " +
+			envOAuthClientID + " or pass --client-id")
+	}
+	secret := os.Getenv(envOAuthClientSecret)
+	if secret == "" {
+		return errors.New("broker: client secret required: set " + envOAuthClientSecret)
+	}
+
+	// The broker's oauth.Config carries the secret and leaves BrokerURL empty, so
+	// its Refresh calls Jira DC directly with the secret on the body. It reuses
+	// oauthHTTPClient so it trusts the internal CA (and honours --insecure).
+	oc := &oauth.Config{
+		BaseURL:      config.baseURL,
+		ClientID:     config.oauthClientID,
+		ClientSecret: secret,
+		HTTPClient:   oauthHTTPClient(config),
+	}
+
+	srv, err := broker.NewServer(broker.Options{
+		Refresh:     brokerRefreshFunc(oc),
+		ClientID:    config.oauthClientID,
+		CallerToken: config.brokerToken,
+		Ready: func() error {
+			if oc.ClientSecret == "" {
+				return errors.New("client secret not configured")
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("broker: %w", err)
+	}
+
+	listen := resolveWithEnv(envBrokerListen, flagStringValue(cmd, flagListen), defaultBrokerListen)
+	tlsCert := resolveWithEnv(envBrokerTLSCert, flagStringValue(cmd, flagTLSCert), "")
+	tlsKey := resolveWithEnv(envBrokerTLSKey, flagStringValue(cmd, flagTLSKey), "")
+	if (tlsCert == "") != (tlsKey == "") {
+		return errors.New("broker: both --" + flagTLSCert + " and --" + flagTLSKey +
+			" are required to serve HTTPS")
+	}
+
+	httpSrv := &http.Server{
+		Addr:              listen,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: brokerReadHeaderTimeout,
+	}
+	return serveBroker(cmdContext(cmd), httpSrv, config, tlsCert, tlsKey)
+}
+
+// serveBroker runs httpSrv until a termination signal (or the parent context)
+// fires, then shuts it down gracefully.
+func serveBroker(
+	parent context.Context, httpSrv *http.Server, config Config, tlsCert, tlsKey string,
+) error {
+	ctx, stop := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	useTLS := tlsCert != "" && tlsKey != ""
+	if !useTLS {
+		slog.Warn("broker serving plain HTTP; terminate TLS at the ingress for transport security",
+			"listen", httpSrv.Addr)
+	}
+	slog.Info("broker listening",
+		"listen", httpSrv.Addr, "base_url", config.baseURL,
+		"caller_token_required", config.brokerToken != "", "tls", useTLS)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if useTLS {
+			errCh <- httpSrv.ListenAndServeTLS(tlsCert, tlsKey)
+		} else {
+			errCh <- httpSrv.ListenAndServe()
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("broker: serve: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		slog.Info("broker shutting down")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), brokerShutdownTimeout)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("broker: shutdown: %w", err)
+		}
+		return nil
+	}
+}
+
+// brokerRefreshFunc adapts oauth.Config.Refresh into a broker.RefreshFunc,
+// translating oauth's sentinel errors into the HTTP status / error code the
+// broker should return. This is the ONLY place the broker's status mapping lives
+// (pkg/broker stays free of any pkg/oauth dependency to avoid an import cycle).
+func brokerRefreshFunc(oc *oauth.Config) broker.RefreshFunc {
+	return func(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
+		tok, err := oc.Refresh(ctx, refreshToken)
+		if err == nil {
+			return tok, nil
+		}
+		switch {
+		case errors.Is(err, oauth.ErrInvalidGrant):
+			// Caller's refresh token is expired/revoked — their problem.
+			return nil, &broker.APIError{
+				Status: http.StatusBadRequest, Code: "invalid_grant", Err: err,
+			}
+		case errors.Is(err, oauth.ErrInvalidClient):
+			// The broker's own secret is misconfigured — a broker problem.
+			return nil, &broker.APIError{
+				Status: http.StatusBadGateway, Code: "invalid_client", Err: err,
+			}
+		default:
+			// invalid (upstream) server errors, timeouts, transport failures.
+			return nil, &broker.APIError{
+				Status: http.StatusServiceUnavailable, Code: "server_error", Err: err,
+			}
+		}
+	}
+}

--- a/cmd/go-jira/broker.go
+++ b/cmd/go-jira/broker.go
@@ -36,17 +36,17 @@ func newBrokerCmd() *cobra.Command {
 		GroupID: groupAuth,
 		Long: `Run the OAuth token refresh broker.
 
-MediaTek's Jira DC OAuth app is a confidential client: its token endpoint
-requires the client_secret on the refresh step. go-jira ships as a public PKCE
-client and must never embed that secret. The broker is a small server-side
-service that holds the client_secret (injected from the environment, e.g. a
-Kubernetes Secret sourced from Vault) and performs only the secret-bearing
-refresh on a client's behalf. Clients set JIRA_TOKEN_BROKER_URL and send their
-refresh_token; the broker adds the secret and returns the rotated token pair.
+A confidential Jira DC OAuth app requires the client_secret on the refresh step.
+go-jira ships as a public PKCE client and must never embed that secret. The
+broker is a small server-side service that holds the client_secret (injected
+from the environment, e.g. a Kubernetes Secret sourced from Vault) and performs
+only the secret-bearing refresh on a client's behalf. Clients set
+JIRA_TOKEN_BROKER_URL and send their refresh_token; the broker adds the secret
+and returns the rotated token pair.
 
-The broker stores no tokens; it keeps only a short-TTL in-memory cache that
-coalesces concurrent refreshes of the same refresh_token into one upstream call
-(handling Jira DC's refresh-token rotation race).`,
+The broker does not persist tokens at rest; it keeps only a short-TTL in-memory
+cache that coalesces concurrent refreshes of the same refresh_token into one
+upstream call (handling Jira DC's refresh-token rotation race).`,
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newBrokerServeCmd())

--- a/cmd/go-jira/broker.go
+++ b/cmd/go-jira/broker.go
@@ -22,6 +22,18 @@ import (
 // guarding against slow-loris clients on the (internal) listener.
 const brokerReadHeaderTimeout = 10 * time.Second
 
+// brokerReadTimeout / brokerWriteTimeout / brokerIdleTimeout bound a full
+// request read, a response write, and a keep-alive idle connection. Together
+// with ReadHeaderTimeout they stop a slow body or slow reader from pinning a
+// connection open indefinitely (a reliability/DoS risk even on internal
+// services). The refresh handler does one short upstream call, so generous
+// fixed values are ample.
+const (
+	brokerReadTimeout  = 30 * time.Second
+	brokerWriteTimeout = 30 * time.Second
+	brokerIdleTimeout  = 120 * time.Second
+)
+
 // brokerShutdownTimeout bounds graceful shutdown after a termination signal.
 const brokerShutdownTimeout = 10 * time.Second
 
@@ -152,6 +164,9 @@ func runBrokerServe(cmd *cobra.Command) error {
 		Addr:              listen,
 		Handler:           srv.Handler(),
 		ReadHeaderTimeout: brokerReadHeaderTimeout,
+		ReadTimeout:       brokerReadTimeout,
+		WriteTimeout:      brokerWriteTimeout,
+		IdleTimeout:       brokerIdleTimeout,
 	}
 	return serveBroker(cmdContext(cmd), httpSrv, config, tlsCert, tlsKey)
 }

--- a/cmd/go-jira/broker.go
+++ b/cmd/go-jira/broker.go
@@ -71,15 +71,19 @@ func newBrokerServeCmd() *cobra.Command {
 		Short: "Start the token refresh broker HTTP server",
 		Long: `Start the token refresh broker HTTP server.
 
-Required environment (fail-fast if missing):
-  JIRA_BASE_URL             Jira DC base URL
-  JIRA_OAUTH_CLIENT_ID      OAuth client ID
-  JIRA_OAUTH_CLIENT_SECRET  confidential client secret (read ONLY from env)
+Required (fail-fast if missing):
+  JIRA_BASE_URL             Jira DC base URL            (or --base-url)
+  JIRA_OAUTH_CLIENT_ID      OAuth client ID             (or --client-id)
+  JIRA_OAUTH_CLIENT_SECRET  confidential client secret  (read ONLY from env)
 
 Optional:
-  JIRA_BROKER_TOKEN         caller bearer token; enforced only when set
-  JIRA_BROKER_LISTEN        listen address (default ` + defaultBrokerListen + `)
-  JIRA_BROKER_TLS_CERT/KEY  serve HTTPS directly (else terminate TLS at ingress)
+  JIRA_BROKER_TOKEN         caller bearer token; enforced only when set (env only)
+  JIRA_BROKER_LISTEN        listen address (default ` + defaultBrokerListen + `) (or --listen)
+  JIRA_BROKER_TLS_CERT/KEY  serve HTTPS directly (or --tls-cert/--tls-key; else terminate TLS at ingress)
+
+Precedence when both an env var and its flag are set: for client ID, listen and
+TLS the environment variable wins; for base URL the --base-url flag wins over
+JIRA_BASE_URL. The secret and caller token are read only from the environment.
 
 Endpoints: POST /v1/refresh, GET /healthz, GET /readyz.`,
 		Example: `  # Run the broker (secret comes from the environment)

--- a/cmd/go-jira/broker_config_test.go
+++ b/cmd/go-jira/broker_config_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was
+// written. runConfigShow renders its table to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+	defer r.Close()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestLoadConfig_BrokerEnvAndFlag verifies the client-side broker fields resolve
+// with env > flag precedence, matching the other OAuth settings.
+func TestLoadConfig_BrokerEnvAndFlag(t *testing.T) {
+	t.Run("env wins over flag", func(t *testing.T) {
+		clearInputEnv(t)
+		t.Setenv(envBrokerURL, "https://broker.env")
+		t.Setenv(envBrokerToken, "token-env")
+
+		cmd := newRunCmd()
+		if err := cmd.ParseFlags([]string{
+			"--broker-url=https://broker.flag",
+			"--broker-token=token-flag",
+		}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		got := loadConfig(cmd)
+		if got.brokerURL != "https://broker.env" {
+			t.Errorf("brokerURL = %q, want env value", got.brokerURL)
+		}
+		if got.brokerToken != "token-env" {
+			t.Errorf("brokerToken = %q, want env value", got.brokerToken)
+		}
+	})
+
+	t.Run("flag used when env unset", func(t *testing.T) {
+		clearInputEnv(t)
+		os.Unsetenv(envBrokerURL)
+		os.Unsetenv(envBrokerToken)
+
+		cmd := newRunCmd()
+		if err := cmd.ParseFlags([]string{"--broker-url=https://broker.flag"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		got := loadConfig(cmd)
+		if got.brokerURL != "https://broker.flag" {
+			t.Errorf("brokerURL = %q, want flag value", got.brokerURL)
+		}
+		if got.brokerToken != "" {
+			t.Errorf("brokerToken = %q, want empty", got.brokerToken)
+		}
+	})
+
+	t.Run("unset by default", func(t *testing.T) {
+		clearInputEnv(t)
+		os.Unsetenv(envBrokerURL)
+		os.Unsetenv(envBrokerToken)
+		got := loadConfig(nil)
+		if got.brokerURL != "" || got.brokerToken != "" {
+			t.Errorf("broker fields = (%q, %q), want both empty by default",
+				got.brokerURL, got.brokerToken)
+		}
+	})
+}
+
+// TestConfigShowBroker verifies `config show` reports the broker URL with its
+// source and redacts the broker token rather than printing it.
+func TestConfigShowBroker(t *testing.T) {
+	clearInputEnv(t)
+	os.Unsetenv(envBrokerURL)
+	os.Unsetenv(envBrokerToken)
+	t.Setenv(envBrokerURL, "https://broker.internal")
+	t.Setenv(envBrokerToken, "super-secret-token")
+
+	out := captureStderr(t, func() {
+		cmd := newConfigShowCmd()
+		if err := cmd.ParseFlags([]string{"--base-url=https://jira.example.com"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if err := runConfigShow(cmd); err != nil {
+			t.Fatalf("runConfigShow: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "broker_url") || !strings.Contains(out, "https://broker.internal") {
+		t.Errorf("config show output missing broker_url value:\n%s", out)
+	}
+	if strings.Contains(out, "super-secret-token") {
+		t.Errorf("config show leaked the broker token:\n%s", out)
+	}
+	if !strings.Contains(out, "broker_token") || !strings.Contains(out, "(set, redacted)") {
+		t.Errorf("config show should mark broker_token as redacted:\n%s", out)
+	}
+}

--- a/cmd/go-jira/broker_config_test.go
+++ b/cmd/go-jira/broker_config_test.go
@@ -115,3 +115,56 @@ func TestConfigShowBroker(t *testing.T) {
 		t.Errorf("config show should mark broker_token as redacted:\n%s", out)
 	}
 }
+
+// TestConfigShowBrokerSourceEnvWins verifies that when BOTH the env var and the
+// flag are set, `config show` reports SOURCE=env for the broker rows — matching
+// resolveWithEnv's env > flag precedence. A flag-first source label would print
+// the env value while claiming it came from the flag.
+func TestConfigShowBrokerSourceEnvWins(t *testing.T) {
+	clearInputEnv(t)
+	t.Setenv(envBrokerURL, "https://broker.fromenv")
+	t.Setenv(envBrokerToken, "token-fromenv")
+
+	out := captureStderr(t, func() {
+		cmd := newConfigShowCmd()
+		if err := cmd.ParseFlags([]string{
+			"--base-url=https://jira.example.com",
+			"--broker-url=https://broker.fromflag",
+			"--broker-token=token-fromflag",
+		}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if err := runConfigShow(cmd); err != nil {
+			t.Fatalf("runConfigShow: %v", err)
+		}
+	})
+
+	// The env value wins, so the broker_url row must report SOURCE=env and show
+	// the env URL, never the overridden flag value.
+	if src := sourceForField(t, out, "broker_url"); src != sourceEnv {
+		t.Errorf("broker_url SOURCE = %q, want %q\n%s", src, sourceEnv, out)
+	}
+	if !strings.Contains(out, "https://broker.fromenv") {
+		t.Errorf("broker_url should show the env value (env wins):\n%s", out)
+	}
+	if strings.Contains(out, "https://broker.fromflag") {
+		t.Errorf("broker_url should NOT show the overridden flag value:\n%s", out)
+	}
+	if src := sourceForField(t, out, "broker_token"); src != sourceEnv {
+		t.Errorf("broker_token SOURCE = %q, want %q\n%s", src, sourceEnv, out)
+	}
+}
+
+// sourceForField returns the SOURCE column (the last whitespace-separated field)
+// of the row whose FIELD column equals field, from a `config show` table.
+func sourceForField(t *testing.T, table, field string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(table, "\n") {
+		cols := strings.Fields(line)
+		if len(cols) >= 2 && cols[0] == field {
+			return cols[len(cols)-1]
+		}
+	}
+	t.Fatalf("field %q not found in table:\n%s", field, table)
+	return ""
+}

--- a/cmd/go-jira/broker_e2e_test.go
+++ b/cmd/go-jira/broker_e2e_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/appleboy/go-jira/pkg/broker"
+	"github.com/appleboy/go-jira/pkg/oauth"
+)
+
+// jiraTokenPath is the Jira DC OAuth token endpoint path (mirrors the unexported
+// constant in pkg/oauth).
+const jiraTokenPath = "/rest/oauth2/latest/token"
+
+// brokerSecret is the confidential client secret the stub broker is configured
+// with; the stub Jira asserts the broker actually forwards it.
+const brokerSecret = "s3cr3t"
+
+// stubJira mimics a Jira DC confidential-client token endpoint: it rejects a
+// refresh that arrives without client_secret (as the real DC does for go-jira's
+// app), so a successful refresh proves the broker added the secret.
+type stubJira struct {
+	upstreamCalls atomic.Int64
+	invalidGrant  bool
+	block         chan struct{} // when non-nil, the handler blocks until closed
+	started       chan struct{} // receives one value when the first request lands
+
+	mu          sync.Mutex
+	lastSecret  string
+	lastRefresh string
+}
+
+func newStubJira(t *testing.T, j *stubJira) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(jiraTokenPath, func(w http.ResponseWriter, r *http.Request) {
+		j.upstreamCalls.Add(1)
+		if j.started != nil {
+			select {
+			case j.started <- struct{}{}:
+			default:
+			}
+		}
+		if j.block != nil {
+			<-j.block
+		}
+		_ = r.ParseForm()
+		j.mu.Lock()
+		j.lastSecret = r.PostForm.Get("client_secret")
+		j.lastRefresh = r.PostForm.Get("refresh_token")
+		j.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if j.invalidGrant {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"revoked"}`))
+			return
+		}
+		if r.PostForm.Get("client_secret") == "" {
+			// Confidential client: refresh without the secret is invalid_client.
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-new",
+			"token_type":    "bearer",
+			"expires_in":    7200,
+			"refresh_token": "refresh-new",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newBrokerFor stands up a real broker server (using the production
+// brokerRefreshFunc wiring) pointed at jiraURL, holding the secret.
+func newBrokerFor(t *testing.T, jiraURL, callerToken string) (*httptest.Server, *broker.Server) {
+	t.Helper()
+	oc := &oauth.Config{
+		BaseURL:      jiraURL,
+		ClientID:     "client-abc",
+		ClientSecret: brokerSecret,
+	}
+	srv, err := broker.NewServer(broker.Options{
+		Refresh:     brokerRefreshFunc(oc),
+		ClientID:    "client-abc",
+		CallerToken: callerToken,
+	})
+	if err != nil {
+		t.Fatalf("broker.NewServer: %v", err)
+	}
+	bs := httptest.NewServer(srv.Handler())
+	t.Cleanup(bs.Close)
+	return bs, srv
+}
+
+// clientConfig builds the client-side oauth.Config through the production
+// oauthConfigFromConfig wiring, so the test also proves the client never sets
+// ClientSecret. brokerURL routes refresh through the broker.
+func clientConfig(t *testing.T, brokerURL, brokerToken string) *oauth.Config {
+	t.Helper()
+	oc := oauthConfigFromConfig(Config{
+		baseURL:       "https://jira.example.com",
+		oauthClientID: "client-abc",
+		scope:         defaultScope,
+		callbackHTTPS: true,
+		brokerURL:     brokerURL,
+		brokerToken:   brokerToken,
+	})
+	if oc.ClientSecret != "" {
+		t.Fatal("client oauth.Config must never carry a ClientSecret")
+	}
+	return oc
+}
+
+// TestBrokerE2EHappyPath: a client configured with a broker refreshes through it;
+// the broker adds the secret and forwards the client's refresh token; the client
+// receives the rotated pair with the correct expiry, via exactly one upstream call.
+func TestBrokerE2EHappyPath(t *testing.T) {
+	j := &stubJira{}
+	jira := newStubJira(t, j)
+	brokerSrv, srv := newBrokerFor(t, jira.URL, "")
+	oc := clientConfig(t, brokerSrv.URL, "")
+
+	tok, err := oc.Refresh(context.Background(), "refresh-old")
+	if err != nil {
+		t.Fatalf("refresh via broker: %v", err)
+	}
+	if tok.AccessToken != "access-new" || tok.RefreshToken != "refresh-new" {
+		t.Errorf("token = %+v, want rotated pair (access-new/refresh-new)", tok)
+	}
+	if rem := time.Until(tok.Expiry); rem < 119*time.Minute || rem > 121*time.Minute {
+		t.Errorf("expiry remaining = %v, want ~120m", rem)
+	}
+	if j.upstreamCalls.Load() != 1 {
+		t.Errorf("upstream calls = %d, want 1", j.upstreamCalls.Load())
+	}
+	if j.lastSecret != brokerSecret {
+		t.Errorf("Jira saw client_secret %q, want the broker to add %q", j.lastSecret, brokerSecret)
+	}
+	if j.lastRefresh != "refresh-old" {
+		t.Errorf("Jira saw refresh_token %q, want the client's refresh-old", j.lastRefresh)
+	}
+	if m := srv.Metrics(); m.RefreshTotal["success"] != 1 || m.UpstreamCalls != 1 {
+		t.Errorf("broker metrics = %+v, want 1 success / 1 upstream", m)
+	}
+}
+
+// TestBrokerE2EConcurrentSameToken: N concurrent refreshes of the SAME refresh
+// token collapse to one upstream call (singleflight) and all callers receive the
+// same rotated pair with no invalid_grant.
+func TestBrokerE2EConcurrentSameToken(t *testing.T) {
+	j := &stubJira{block: make(chan struct{}), started: make(chan struct{}, 1)}
+	jira := newStubJira(t, j)
+	brokerSrv, srv := newBrokerFor(t, jira.URL, "")
+	oc := clientConfig(t, brokerSrv.URL, "")
+
+	const n = 12
+	var wg sync.WaitGroup
+	accessTokens := make([]string, n)
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tok, err := oc.Refresh(context.Background(), "refresh-old")
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			accessTokens[i] = tok.AccessToken
+		}(i)
+	}
+
+	<-j.started                        // the single executor has reached Jira
+	time.Sleep(100 * time.Millisecond) // let the rest coalesce as inflight waiters
+	close(j.block)
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Errorf("caller %d errored: %v", i, errs[i])
+		}
+		if accessTokens[i] != "access-new" {
+			t.Errorf("caller %d got %q, want access-new", i, accessTokens[i])
+		}
+	}
+	if j.upstreamCalls.Load() != 1 {
+		t.Errorf("upstream_call_count = %d, want 1", j.upstreamCalls.Load())
+	}
+	if m := srv.Metrics(); m.UpstreamCalls != 1 || m.CacheHits != n-1 {
+		t.Errorf("broker metrics = %+v, want 1 upstream / %d cache hits", m, n-1)
+	}
+}
+
+// TestBrokerE2EInvalidGrant: an expired refresh token surfaces as
+// oauth.ErrInvalidGrant on the client, which the CLI classifies as an auth
+// failure and hints to run `go-jira login` again.
+func TestBrokerE2EInvalidGrant(t *testing.T) {
+	j := &stubJira{invalidGrant: true}
+	jira := newStubJira(t, j)
+	brokerSrv, _ := newBrokerFor(t, jira.URL, "")
+	oc := clientConfig(t, brokerSrv.URL, "")
+
+	_, err := oc.Refresh(context.Background(), "dead-token")
+	if !errors.Is(err, oauth.ErrInvalidGrant) {
+		t.Fatalf("error = %v, want errors.Is oauth.ErrInvalidGrant", err)
+	}
+
+	// Mirror runTokenRefresh's wrapping and verify the CLI recovery hint.
+	ce := classify(fmt.Errorf("refresh failed: %w", err), nil)
+	if ce.code != exitAuth {
+		t.Errorf("exit code = %d, want %d (auth)", ce.code, exitAuth)
+	}
+	addHint(ce, newRootCmd())
+	if !strings.Contains(strings.ToLower(ce.hint), "login") {
+		t.Errorf("hint = %q, want it to mention `login`", ce.hint)
+	}
+}
+
+// TestBrokerE2ECallerAuth: when the broker requires a caller token, a request
+// without it is rejected with no upstream call; the correct token succeeds.
+func TestBrokerE2ECallerAuth(t *testing.T) {
+	j := &stubJira{}
+	jira := newStubJira(t, j)
+	brokerSrv, srv := newBrokerFor(t, jira.URL, "broker-secret")
+
+	// Missing caller token: rejected, broker never calls Jira.
+	noToken := clientConfig(t, brokerSrv.URL, "")
+	if _, err := noToken.Refresh(context.Background(), "refresh-old"); err == nil {
+		t.Fatal("expected an error when broker requires a caller token")
+	}
+	if j.upstreamCalls.Load() != 0 {
+		t.Errorf("upstream calls = %d on auth failure, want 0", j.upstreamCalls.Load())
+	}
+	if m := srv.Metrics(); m.RefreshTotal["unauthorized"] != 1 {
+		t.Errorf("unauthorized metric = %d, want 1", m.RefreshTotal["unauthorized"])
+	}
+
+	// Correct caller token: succeeds.
+	withToken := clientConfig(t, brokerSrv.URL, "broker-secret")
+	tok, err := withToken.Refresh(context.Background(), "refresh-old")
+	if err != nil {
+		t.Fatalf("refresh with correct caller token: %v", err)
+	}
+	if tok.AccessToken != "access-new" {
+		t.Errorf("access token = %q, want access-new", tok.AccessToken)
+	}
+}

--- a/cmd/go-jira/broker_e2e_test.go
+++ b/cmd/go-jira/broker_e2e_test.go
@@ -193,8 +193,12 @@ func TestBrokerE2EConcurrentSameToken(t *testing.T) {
 		}(i)
 	}
 
-	<-j.started                        // the single executor has reached Jira
-	time.Sleep(100 * time.Millisecond) // let the rest coalesce as inflight waiters
+	<-j.started // the single executor has reached Jira and is held there
+	// No sleep needed: the executor's upstream call is held open on j.block, so
+	// every other caller either coalesces onto it or — once it completes and the
+	// rotated pair is cached — is served from that cache. Neither path makes a
+	// second upstream call, so upstream==1 and cache_hits==n-1 hold regardless of
+	// goroutine scheduling.
 	close(j.block)
 	wg.Wait()
 

--- a/cmd/go-jira/broker_e2e_test.go
+++ b/cmd/go-jira/broker_e2e_test.go
@@ -39,6 +39,15 @@ type stubJira struct {
 	lastRefresh string
 }
 
+// lastSeen returns the client_secret and refresh_token the stub last received,
+// read under the same mutex the handler writes them with so assertions are
+// race-free under `go test -race`.
+func (j *stubJira) lastSeen() (secret, refresh string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.lastSecret, j.lastRefresh
+}
+
 func newStubJira(t *testing.T, j *stubJira) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -146,11 +155,12 @@ func TestBrokerE2EHappyPath(t *testing.T) {
 	if j.upstreamCalls.Load() != 1 {
 		t.Errorf("upstream calls = %d, want 1", j.upstreamCalls.Load())
 	}
-	if j.lastSecret != brokerSecret {
-		t.Errorf("Jira saw client_secret %q, want the broker to add %q", j.lastSecret, brokerSecret)
+	lastSecret, lastRefresh := j.lastSeen()
+	if lastSecret != brokerSecret {
+		t.Errorf("Jira saw client_secret %q, want the broker to add %q", lastSecret, brokerSecret)
 	}
-	if j.lastRefresh != "refresh-old" {
-		t.Errorf("Jira saw refresh_token %q, want the client's refresh-old", j.lastRefresh)
+	if lastRefresh != "refresh-old" {
+		t.Errorf("Jira saw refresh_token %q, want the client's refresh-old", lastRefresh)
 	}
 	if m := srv.Metrics(); m.RefreshTotal["success"] != 1 || m.UpstreamCalls != 1 {
 		t.Errorf("broker metrics = %+v, want 1 success / 1 upstream", m)

--- a/cmd/go-jira/broker_serve_test.go
+++ b/cmd/go-jira/broker_serve_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBrokerServeFailFast verifies `broker serve` refuses to start when required
+// configuration is missing, so a misconfigured broker never silently fails every
+// refresh. In particular the client secret must be present (and is read only from
+// the environment).
+func TestBrokerServeFailFast(t *testing.T) {
+	t.Run("missing client secret", func(t *testing.T) {
+		clearInputEnv(t)
+		t.Setenv(envBaseURL, "https://jira.example.com")
+		t.Setenv(envOAuthClientID, "client-abc")
+		t.Setenv(envOAuthClientSecret, "")
+
+		cmd := newBrokerServeCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		err := runBrokerServe(cmd)
+		if err == nil || !strings.Contains(err.Error(), "client secret required") {
+			t.Fatalf("error = %v, want it to require the client secret", err)
+		}
+	})
+
+	t.Run("missing client id", func(t *testing.T) {
+		clearInputEnv(t)
+		t.Setenv(envBaseURL, "https://jira.example.com")
+		t.Setenv(envOAuthClientID, "")
+		t.Setenv(envOAuthClientSecret, "s3cr3t")
+
+		cmd := newBrokerServeCmd()
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		err := runBrokerServe(cmd)
+		if err == nil || !strings.Contains(err.Error(), "client ID required") {
+			t.Fatalf("error = %v, want it to require the client ID", err)
+		}
+	})
+}

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -49,6 +49,11 @@ type Config struct {
 	callbackCert            string
 	callbackKey             string
 	callbackHTTPS           bool
+
+	// Token refresh broker (client-side). brokerURL routes refresh through the
+	// broker; brokerToken is the optional caller bearer token sent to it.
+	brokerURL   string
+	brokerToken string
 }
 
 // loadConfig resolves configuration from CLI flags (when explicitly set)
@@ -149,6 +154,10 @@ func loadConfig(cmd *cobra.Command) Config {
 	)
 	cfg.callbackHTTPS = resolveCallbackHTTPS(cmd)
 
+	// Token refresh broker (client-side): env > flag, no embedded default.
+	cfg.brokerURL = resolveWithEnv(envBrokerURL, flagStringValue(cmd, flagBrokerURL), "")
+	cfg.brokerToken = resolveWithEnv(envBrokerToken, flagStringValue(cmd, flagBrokerToken), "")
+
 	warnOnSecretFlags(cmd)
 	return cfg
 }
@@ -159,7 +168,7 @@ func warnOnSecretFlags(cmd *cobra.Command) {
 	if cmd == nil {
 		return
 	}
-	for _, name := range []string{flagPassword, flagToken} {
+	for _, name := range []string{flagPassword, flagToken, flagBrokerToken} {
 		if cmd.Flags().Lookup(name) != nil && cmd.Flags().Changed(name) {
 			slog.Warn(
 				"passing secrets via CLI flag is unsafe on shared hosts; prefer env vars or .env",

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -15,6 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// URL schemes recognised for the Jira base URL, the OAuth callback, and the
+// token refresh broker URL.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
 // Config holds the application configuration.
 type Config struct {
 	baseURL      string
@@ -159,7 +166,27 @@ func loadConfig(cmd *cobra.Command) Config {
 	cfg.brokerToken = resolveWithEnv(envBrokerToken, flagStringValue(cmd, flagBrokerToken), "")
 
 	warnOnSecretFlags(cmd)
+	warnOnInsecureBrokerURL(cfg.brokerURL)
 	return cfg
+}
+
+// warnOnInsecureBrokerURL warns when the token refresh broker URL uses cleartext
+// http: the refresh token (and any broker bearer token) would then be sent
+// unencrypted to the broker. https — or TLS terminated at an ingress in front of
+// the broker — is strongly preferred. The warning is advisory (not a hard error)
+// so loopback/dev setups still work, mirroring the broker server's own
+// plain-HTTP warning in serveBroker.
+func warnOnInsecureBrokerURL(brokerURL string) {
+	if brokerURL == "" {
+		return
+	}
+	if u, err := url.Parse(brokerURL); err == nil && u.Scheme == schemeHTTP {
+		slog.Warn(
+			"token refresh broker URL uses cleartext http; the refresh token and broker "+
+				"token are sent unencrypted — use https or terminate TLS in front of the broker",
+			"broker_url", brokerURL,
+		)
+	}
 }
 
 // warnOnSecretFlags warns when secrets arrive via CLI flag — they leak into ps
@@ -294,9 +321,9 @@ func resolveWithEnv(envKey, flagVal, embedded string) string {
 // TLS cert+key pair or the auto-generated cert (--callback-https), both of which
 // Jira DC needs since it rejects an http redirect URI — and http otherwise.
 func (c Config) redirectURI() string {
-	scheme := "http"
+	scheme := schemeHTTP
 	if c.callbackHTTPS || (c.callbackCert != "" && c.callbackKey != "") {
-		scheme = "https"
+		scheme = schemeHTTPS
 	}
 	return fmt.Sprintf("%s://127.0.0.1:%d/callback", scheme, c.callbackPort)
 }
@@ -315,8 +342,8 @@ func validateBaseURL(config Config) error {
 		return errors.New("base_url must be a valid URL")
 	}
 	switch u.Scheme {
-	case "https":
-	case "http":
+	case schemeHTTPS:
+	case schemeHTTP:
 		if !config.insecure {
 			return errors.New("base_url must use https; pass --insecure=true to allow http")
 		}

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -62,16 +62,22 @@ func runConfigShow(cmd *cobra.Command) error {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", field, redactIfSecret(field, value),
 			configSource(cmd, flagName, envKey, aliasEnv))
 	}
+	// oauthRow is row's sibling for fields that resolve env > flag (resolveWithEnv
+	// precedence): their SOURCE must be reported env-first via oauthValueSource, not
+	// the flag-first configSource — otherwise an env-overridden value is mislabelled
+	// as coming from the flag when both are set.
+	oauthRow := func(field, value, flagName, envKey, embedded string) {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", field, redactIfSecret(field, value),
+			oauthValueSource(cmd, flagName, envKey, value, embedded))
+	}
 
 	row("base_url", config.baseURL, flagBaseURL, "base_url", envBaseURL)
 	row("insecure", fmt.Sprintf("%t", config.insecure), flagInsecure, "insecure", envInsecure)
 	row("token", config.token, flagToken, "token", envToken)
 	row("username", config.username, flagUsername, "username", envUsername)
 	row("password", config.password, flagPassword, "password", envPassword)
-	fmt.Fprintf(w, "oauth_client_id\t%s\t%s\n",
-		redactIfSecret("oauth_client_id", config.oauthClientID),
-		oauthValueSource(cmd, flagClientID, envOAuthClientID, config.oauthClientID,
-			DefaultOAuthClientID))
+	oauthRow("oauth_client_id", config.oauthClientID, flagClientID, envOAuthClientID,
+		DefaultOAuthClientID)
 	row("scope", config.scope, flagScope, "", "")
 	// oauth-env (CI) inputs: show presence/source without leaking the token.
 	fmt.Fprintf(w, "oauth_refresh_token\t%s\t%s\n",
@@ -80,17 +86,10 @@ func runConfigShow(cmd *cobra.Command) error {
 	fmt.Fprintf(w, "oauth_refresh_token_output\t%s\t%s\n",
 		redactIfSecret("oauth_refresh_token_output", config.oauthRefreshTokenOutput),
 		configSource(cmd, "", "", envOAuthRefreshTokenOutput))
-	// Token refresh broker (client-side): these resolve with resolveWithEnv (env >
-	// flag), so report the source env-first via oauthValueSource — the generic,
-	// flag-first configSource would mislabel an env-overridden value as coming from
-	// the flag when both are set. The broker token is still redacted by
+	// Token refresh broker (client-side): broker_token is redacted by
 	// redactIfSecret; the URL is not secret and is shown in full.
-	fmt.Fprintf(w, "broker_url\t%s\t%s\n",
-		redactIfSecret("broker_url", config.brokerURL),
-		oauthValueSource(cmd, flagBrokerURL, envBrokerURL, config.brokerURL, ""))
-	fmt.Fprintf(w, "broker_token\t%s\t%s\n",
-		redactIfSecret("broker_token", config.brokerToken),
-		oauthValueSource(cmd, flagBrokerToken, envBrokerToken, config.brokerToken, ""))
+	oauthRow("broker_url", config.brokerURL, flagBrokerURL, envBrokerURL, "")
+	oauthRow("broker_token", config.brokerToken, flagBrokerToken, envBrokerToken, "")
 	fmt.Fprintf(w, "auth_mode\t%s\t%s\n", detectAuthMode(config), "resolved")
 
 	return w.Flush()

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -80,11 +80,17 @@ func runConfigShow(cmd *cobra.Command) error {
 	fmt.Fprintf(w, "oauth_refresh_token_output\t%s\t%s\n",
 		redactIfSecret("oauth_refresh_token_output", config.oauthRefreshTokenOutput),
 		configSource(cmd, "", "", envOAuthRefreshTokenOutput))
-	// Token refresh broker (client-side): show the URL and the source, and the
-	// presence of the optional broker token without revealing it (row() redacts it
-	// via redactIfSecret).
-	row("broker_url", config.brokerURL, flagBrokerURL, "", envBrokerURL)
-	row("broker_token", config.brokerToken, flagBrokerToken, "", envBrokerToken)
+	// Token refresh broker (client-side): these resolve with resolveWithEnv (env >
+	// flag), so report the source env-first via oauthValueSource — the generic,
+	// flag-first configSource would mislabel an env-overridden value as coming from
+	// the flag when both are set. The broker token is still redacted by
+	// redactIfSecret; the URL is not secret and is shown in full.
+	fmt.Fprintf(w, "broker_url\t%s\t%s\n",
+		redactIfSecret("broker_url", config.brokerURL),
+		oauthValueSource(cmd, flagBrokerURL, envBrokerURL, config.brokerURL, ""))
+	fmt.Fprintf(w, "broker_token\t%s\t%s\n",
+		redactIfSecret("broker_token", config.brokerToken),
+		oauthValueSource(cmd, flagBrokerToken, envBrokerToken, config.brokerToken, ""))
 	fmt.Fprintf(w, "auth_mode\t%s\t%s\n", detectAuthMode(config), "resolved")
 
 	return w.Flush()

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -80,6 +80,11 @@ func runConfigShow(cmd *cobra.Command) error {
 	fmt.Fprintf(w, "oauth_refresh_token_output\t%s\t%s\n",
 		redactIfSecret("oauth_refresh_token_output", config.oauthRefreshTokenOutput),
 		configSource(cmd, "", "", envOAuthRefreshTokenOutput))
+	// Token refresh broker (client-side): show the URL and the source, and the
+	// presence of the optional broker token without revealing it (row() redacts it
+	// via redactIfSecret).
+	row("broker_url", config.brokerURL, flagBrokerURL, "", envBrokerURL)
+	row("broker_token", config.brokerToken, flagBrokerToken, "", envBrokerToken)
 	fmt.Fprintf(w, "auth_mode\t%s\t%s\n", detectAuthMode(config), "resolved")
 
 	return w.Flush()
@@ -169,7 +174,7 @@ func redactIfSecret(field, value string) string {
 		return "(unset)"
 	}
 	switch field {
-	case flagToken, flagPassword, "oauth_refresh_token":
+	case flagToken, flagPassword, "oauth_refresh_token", "broker_token":
 		return "(set, redacted)"
 	default:
 		return value

--- a/cmd/go-jira/errors.go
+++ b/cmd/go-jira/errors.go
@@ -150,10 +150,13 @@ func classify(err error, diag *requestDiag) *cliError {
 	if isUsageError(msg) {
 		return &cliError{code: exitUsage, kind: kindUsage, message: msg, err: err}
 	}
-	// oauth.ErrInvalidGrant (refresh token expired or revoked) surfaces from a
-	// direct refresh call with no HTTP diagnostics and no "auth ..." message
-	// prefix, so match it by error identity to keep all auth classification here.
-	if isAuthError(msg) || errors.Is(err, oauth.ErrInvalidGrant) {
+	// oauth.ErrInvalidGrant (refresh token expired or revoked) and
+	// oauth.ErrBrokerUnauthorized (broker rejected the caller token) surface from
+	// a refresh call with no HTTP diagnostics and no "auth ..." message prefix, so
+	// match them by error identity to keep all auth classification here.
+	if isAuthError(msg) ||
+		errors.Is(err, oauth.ErrInvalidGrant) ||
+		errors.Is(err, oauth.ErrBrokerUnauthorized) {
 		return &cliError{code: exitAuth, kind: kindAuth, message: msg, err: err}
 	}
 	return &cliError{code: exitError, kind: kindError, message: msg, err: err}
@@ -244,6 +247,13 @@ func addHint(ce *cliError, root *cobra.Command) {
 		ce.hint = fmt.Sprintf("Run %q for usage and examples.", rootName(root)+" --help")
 	case kindAuth:
 		name := rootName(root)
+		if errors.Is(ce.err, oauth.ErrBrokerUnauthorized) {
+			// A broker 401 is about the caller's broker token, not the user's Jira
+			// login, so the generic refresh/login hint below would misdirect.
+			ce.hint = "The token refresh broker rejected the caller credential; " +
+				"set or correct the broker token (JIRA_BROKER_TOKEN or --broker-token)."
+			return
+		}
 		if errors.Is(ce.err, oauth.ErrInvalidGrant) {
 			// The refresh token itself is dead, so suggesting `token refresh`
 			// would be self-referential (it is what just failed) and loop an

--- a/cmd/go-jira/errors_test.go
+++ b/cmd/go-jira/errors_test.go
@@ -91,6 +91,35 @@ func TestClassifyInvalidGrantIsAuth(t *testing.T) {
 	}
 }
 
+// oauth.ErrBrokerUnauthorized (the broker rejected the caller's broker token) is
+// a 401-class auth failure. Like ErrInvalidGrant it carries no "auth ..." prefix
+// and no HTTP diagnostics, so only errors.Is can catch it — this is what makes a
+// broker 401 exit 3 (not 1) consistently across the manual `token refresh` path
+// (which wraps "refresh failed: %w") and the auto-refresh paths.
+func TestClassifyBrokerUnauthorizedIsAuth(t *testing.T) {
+	err := fmt.Errorf("refresh failed: %w", oauth.ErrBrokerUnauthorized)
+	ce := classify(err, &requestDiag{})
+	if ce.code != exitAuth || ce.kind != kindAuth {
+		t.Fatalf("got code=%d kind=%q, want code=%d kind=%q",
+			ce.code, ce.kind, exitAuth, kindAuth)
+	}
+}
+
+// TestAddHintBrokerUnauthorizedPointsAtBrokerToken verifies that a broker 401
+// hint targets the broker token, not the user's Jira login/refresh — a broker
+// caller-credential failure is unrelated to the stored Jira token.
+func TestAddHintBrokerUnauthorizedPointsAtBrokerToken(t *testing.T) {
+	root := newRootCmd()
+	ce := classify(fmt.Errorf("refresh failed: %w", oauth.ErrBrokerUnauthorized), &requestDiag{})
+	addHint(ce, root)
+	if !strings.Contains(ce.hint, "broker token") {
+		t.Fatalf("hint = %q, want it to mention the broker token", ce.hint)
+	}
+	if strings.Contains(ce.hint, "go-jira login") {
+		t.Fatalf("hint = %q, want it NOT to suggest login (unrelated to a broker 401)", ce.hint)
+	}
+}
+
 // TestAddHintInvalidGrantPointsAtLogin verifies that for a refresh token that
 // is expired or revoked (oauth.ErrInvalidGrant), the hint points straight at
 // `login` and does NOT suggest `token refresh` — that command is what just

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -75,6 +75,15 @@ const (
 	flagScope         = "scope"
 	flagTimeout       = "timeout"
 	flagConfirm       = "confirm"
+
+	// Token refresh broker flags. --broker-url / --broker-token are client-side
+	// (route refresh through the broker); --listen / --tls-cert / --tls-key are
+	// broker-server-side (the `broker serve` subcommand).
+	flagBrokerURL   = "broker-url"
+	flagBrokerToken = "broker-token"
+	flagListen      = "listen"
+	flagTLSCert     = "tls-cert"
+	flagTLSKey      = "tls-key"
 )
 
 // OAuth environment variables. Unlike the action config (which uses the
@@ -89,6 +98,21 @@ const (
 	envOAuthCallbackKey        = "JIRA_OAUTH_CALLBACK_KEY"
 	envOAuthCallbackHTTPS      = "JIRA_OAUTH_CALLBACK_HTTPS"
 	envMasterPassword          = "JIRA_MASTER_PASSWORD"
+
+	// Token refresh broker env vars.
+	//   - envBrokerURL is client-side: route refresh through this broker.
+	//   - envBrokerToken is the shared caller bearer token: the client sends it,
+	//     and the broker enforces it only when set there too.
+	//   - envOAuthClientSecret is broker-ONLY: the confidential client_secret,
+	//     injected from a K8s Secret / Vault. It must never be set on a client.
+	//   - envBrokerListen / envBrokerTLSCert / envBrokerTLSKey configure the
+	//     broker's own HTTP(S) listener.
+	envBrokerURL         = "JIRA_TOKEN_BROKER_URL"
+	envBrokerToken       = "JIRA_BROKER_TOKEN"        //nolint:gosec // env var name, not a secret
+	envOAuthClientSecret = "JIRA_OAUTH_CLIENT_SECRET" //nolint:gosec // env var name, not a secret
+	envBrokerListen      = "JIRA_BROKER_LISTEN"
+	envBrokerTLSCert     = "JIRA_BROKER_TLS_CERT"
+	envBrokerTLSKey      = "JIRA_BROKER_TLS_KEY"
 
 	// JIRA_-prefixed aliases for the core auth/config fields, matching the env
 	// naming used throughout the docs and the auth-resolver error message. The
@@ -105,6 +129,10 @@ const (
 const (
 	defaultCallbackPort = 8765
 	defaultScope        = "WRITE"
+
+	// defaultBrokerListen is the broker server's default listen address. In
+	// Kubernetes the Service maps a stable port to this container port.
+	defaultBrokerListen = ":8080"
 
 	// Default custom field IDs used by the data subcommands that reference
 	// epic/sprint (create, update, and search). These match the documented Jira
@@ -253,6 +281,7 @@ Composability:
 		newLogoutCmd(),
 		newWhoamiCmd(),
 		newTokenCmd(),
+		newBrokerCmd(),
 		newConfigCmd(),
 		newSearchCmd(),
 		newCreateCmd(),
@@ -355,6 +384,11 @@ func addOAuthFlags(cmd *cobra.Command) {
 			"no cert/key files are needed (env: "+envOAuthCallbackHTTPS+
 			"); the browser shows a one-time security warning to accept")
 	cmd.Flags().String(flagScope, defaultScope, "OAuth scope to request")
+	cmd.Flags().String(flagBrokerURL, "",
+		"Token refresh broker base URL; when set, refresh is routed through the "+
+			"broker instead of calling Jira directly (env: "+envBrokerURL+")")
+	cmd.Flags().String(flagBrokerToken, "",
+		"Optional bearer token sent to the broker (env: "+envBrokerToken+")")
 }
 
 // loadEnvFile resolves and loads an env file, logging the absolute path that

--- a/cmd/go-jira/oauthcli.go
+++ b/cmd/go-jira/oauthcli.go
@@ -147,6 +147,10 @@ func oauthConfigFromConfig(config Config) *oauth.Config {
 		TLSKeyFile:      config.callbackKey,
 		GenerateTLSCert: config.callbackHTTPS,
 		HTTPClient:      oauthHTTPClient(config),
+		// Client-side broker routing for refresh. ClientSecret is deliberately
+		// never set here: only the broker process holds the secret.
+		BrokerURL:   config.brokerURL,
+		BrokerToken: config.brokerToken,
 	}
 }
 

--- a/cmd/go-jira/run.go
+++ b/cmd/go-jira/run.go
@@ -201,6 +201,10 @@ func authConfigFromRun(config Config) auth.Config {
 		OAuthRedirectURI:  config.redirectURI(),
 		OAuthScopes:       []string{config.scope},
 		OAuthHTTPClient:   oauthHTTPClient(config),
+		// Route the auto-refresh (401) and oauth-env refreshes through the broker
+		// when configured, matching the manual `token refresh` path.
+		BrokerURL:   config.brokerURL,
+		BrokerToken: config.brokerToken,
 	}
 	if config.oauthRefreshToken != "" {
 		cfg.OnRotate = rotationWriter(config.oauthRefreshTokenOutput)

--- a/docs/oauth-usage.md
+++ b/docs/oauth-usage.md
@@ -149,6 +149,102 @@ refresh token for an access token at startup.
 A complete GitHub Actions example, including the secret write-back step, is in
 [`.github/workflows/example-oauth-ci.yml`](../.github/workflows/example-oauth-ci.yml).
 
+## 6. Token refresh broker (confidential clients)
+
+Some Jira DC OAuth applications are **confidential clients**: their token
+endpoint **requires `client_secret` on the `grant_type=refresh_token` step**. A
+published binary must never embed that secret (`strings` would reveal it), so
+go-jira can route **only the refresh step** through a server-side **token refresh
+broker** that holds the secret. **Login is unchanged** — it stays a direct public
+PKCE flow; the broker is involved on refresh only.
+
+```
+go-jira login    ──(public PKCE, no secret)──────────────────────▶ Jira DC   [unchanged]
+
+go-jira refresh  ──refresh_token──────────────▶ broker ──refresh_token + client_id + client_secret ─▶ Jira DC
+                 ◀────── new token pair ───────        ◀───────────── rotated token pair ────────────
+```
+
+When `JIRA_TOKEN_BROKER_URL` is unset, behaviour is **identical to today** (direct
+refresh). The CLI **never** holds the secret.
+
+### Client setup
+
+| Env var                 | Flag             | Required | Purpose                                                  |
+| ----------------------- | ---------------- | -------- | -------------------------------------------------------- |
+| `JIRA_TOKEN_BROKER_URL` | `--broker-url`   | to use   | Broker base URL; routes refresh through the broker       |
+| `JIRA_BROKER_TOKEN`     | `--broker-token` | optional | Caller bearer token (see security model)                 |
+
+All three refresh paths use the broker once `JIRA_TOKEN_BROKER_URL` is set:
+`go-jira token refresh`, the automatic refresh after a `401`, and the `oauth-env`
+(CI) initial refresh. `go-jira config show` reports `broker_url` (and a redacted
+`broker_token`) with their source.
+
+### Broker deployment (Kubernetes + Vault)
+
+Run the **same binary** as a subcommand: `go-jira broker serve`. The secret is
+injected from a **K8s Secret sourced from Vault** (Vault Agent, Secrets Store
+CSI, or external-secrets) — never built into the image, never in ldflags.
+
+| Env var                    | Required | Purpose                                                          |
+| -------------------------- | -------- | --------------------------------------------------------------- |
+| `JIRA_BASE_URL`            | yes      | Jira instance base URL                                          |
+| `JIRA_OAUTH_CLIENT_ID`     | yes      | OAuth client ID (also matched against a request's `client_id`)  |
+| `JIRA_OAUTH_CLIENT_SECRET` | yes      | Confidential client secret — **read only here, only from env**  |
+| `JIRA_BROKER_TOKEN`        | optional | Required caller bearer token; enforced **only when set**        |
+| `JIRA_BROKER_LISTEN`       | optional | Listen address (default `:8080`); flag `--listen`               |
+| `JIRA_BROKER_TLS_CERT/KEY` | optional | Serve HTTPS directly; otherwise terminate TLS at the ingress    |
+
+The broker **fails fast** if `JIRA_BASE_URL`, `JIRA_OAUTH_CLIENT_ID`, or
+`JIRA_OAUTH_CLIENT_SECRET` is missing.
+
+Endpoints:
+
+- `POST /v1/refresh` — body `{"refresh_token":"…"}` (optional `client_id`,
+  verified against the broker's own); returns the rotated OAuth token pair, or an
+  OAuth-style error: `400 invalid_grant` (token expired/revoked), `502
+  invalid_client` (the **broker's** secret is misconfigured), `401`
+  (caller-token check failed), `503` (upstream timeout / 5xx).
+- `GET /healthz` — liveness; never touches the secret.
+- `GET /readyz` — readiness; reports not-ready (`503`) until the secret is present.
+
+**Refresh-token rotation race.** Jira DC invalidates the old refresh token on
+every successful refresh, so concurrent refreshes of the same token would race.
+The broker coalesces concurrent calls for one refresh token into a **single**
+upstream call (per-key request coalescing) and reuses the result for a short TTL
+(default 60s). The cache is **purely in-memory, never persisted, never logged**;
+the broker stores **no** tokens. With multiple replicas the cache is per-replica,
+so a rare cross-replica race just makes a client retry — use sticky routing if
+that matters.
+
+### Security model
+
+- **Primary control: the network.** Put the broker behind a **K8s NetworkPolicy
+  + internal-only ingress** so only approved sources can reach it, always over
+  TLS. A leaked refresh token alone is useless without network access to the
+  broker — a control a CLI cannot steal.
+- **Optional caller token (`JIRA_BROKER_TOKEN`).** Defence in depth, enforced
+  only when set. ⚠️ It is **only meaningful when it comes from a different trust
+  source than the refresh token** (e.g. a CI secret store). If it sits in the
+  **same `.env` as the refresh token**, it adds **no** protection against host/
+  file compromise — do not treat it as the primary control.
+- **Upgrade to mTLS** (certs issued/rotated by the service mesh or ingress) when
+  you need a real caller identity rather than a shared string.
+- **Accepted residual risk.** Without a caller token, "reach the broker + hold a
+  valid refresh token" is enough to refresh. Mitigate with network restriction,
+  short-lived refresh tokens + Jira's existing rotation, and broker-side logging
+  / rate limiting / anomaly alerts.
+- **Rotation needs no rebuild.** Rotate `client_secret` (update Vault/Secret →
+  rolling restart) or `JIRA_BROKER_TOKEN` (update the Secret + re-issue to
+  callers → rolling restart) **without** rebuilding or republishing the binary.
+
+### Observability
+
+Each request emits a structured log with the refresh token's **sha256 prefix**
+(never the token), cache hit/miss, upstream status, and `latency_ms` — **no
+secret or token is ever logged**. In-process counters track `refresh_total` by
+result, `upstream_calls_total`, and `cache_hits_total`.
+
 ## Building with an embedded client
 
 To ship a binary with the company-wide client baked in:

--- a/docs/oauth-usage.md
+++ b/docs/oauth-usage.md
@@ -213,9 +213,9 @@ every successful refresh, so concurrent refreshes of the same token would race.
 The broker coalesces concurrent calls for one refresh token into a **single**
 upstream call (per-key request coalescing) and reuses the result for a short TTL
 (default 60s). The cache is **purely in-memory, never persisted, never logged**;
-the broker stores **no** tokens. With multiple replicas the cache is per-replica,
-so a rare cross-replica race just makes a client retry — use sticky routing if
-that matters.
+the broker **does not persist tokens at rest**. With multiple replicas the cache
+is per-replica, so a rare cross-replica race just makes a client retry — use
+sticky routing if that matters.
 
 ### Security model
 

--- a/docs/oauth-usage.md
+++ b/docs/oauth-usage.md
@@ -158,12 +158,23 @@ go-jira can route **only the refresh step** through a server-side **token refres
 broker** that holds the secret. **Login is unchanged** — it stays a direct public
 PKCE flow; the broker is involved on refresh only.
 
+```mermaid
+flowchart LR
+    subgraph login["go-jira login — unchanged"]
+        direction LR
+        CLI1["CLI"] -->|"public PKCE, no secret"| J1["Jira DC"]
+    end
+    subgraph refresh["go-jira token refresh — via broker"]
+        direction LR
+        CLI2["CLI"] -->|"refresh_token + client_id"| B["broker<br/>(holds client_secret)"]
+        B -->|"refresh_token + client_id + client_secret"| J2["Jira DC"]
+        J2 -->|"rotated token pair"| B
+        B -->|"new token pair"| CLI2
+    end
 ```
-go-jira login    ──(public PKCE, no secret)──────────────────────▶ Jira DC   [unchanged]
 
-go-jira refresh  ──refresh_token──────────────▶ broker ──refresh_token + client_id + client_secret ─▶ Jira DC
-                 ◀────── new token pair ───────        ◀───────────── rotated token pair ────────────
-```
+Login stays a direct public PKCE flow with **no secret**; only `go-jira token
+refresh` routes through the broker, which adds the `client_secret` upstream.
 
 When `JIRA_TOKEN_BROKER_URL` is unset, behaviour is **identical to today** (direct
 refresh). The CLI **never** holds the secret.
@@ -206,7 +217,10 @@ Endpoints:
   invalid_client` (the **broker's** secret is misconfigured), `401`
   (caller-token check failed), `503` (upstream timeout / 5xx).
 - `GET /healthz` — liveness; never touches the secret.
-- `GET /readyz` — readiness; reports not-ready (`503`) until the secret is present.
+- `GET /readyz` — readiness; returns `200` once the process is serving. Because
+  the broker **fails fast** at startup when the secret is missing, it is ready as
+  soon as it accepts connections; the check is a defensive guard that mirrors
+  that invariant (it returns `503` only if the in-memory secret is ever absent).
 
 **Refresh-token rotation race.** Jira DC invalidates the old refresh token on
 every successful refresh, so concurrent refreshes of the same token would race.
@@ -216,6 +230,23 @@ upstream call (per-key request coalescing) and reuses the result for a short TTL
 the broker **does not persist tokens at rest**. With multiple replicas the cache
 is per-replica, so a rare cross-replica race just makes a client retry — use
 sticky routing if that matters.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C1 as CLI #1
+    participant C2 as CLI #2 (same token T)
+    participant B as broker
+    participant J as Jira DC
+    C1->>B: POST /v1/refresh (token T)
+    C2->>B: POST /v1/refresh (token T)
+    Note over B: coalesce by sha256(T) —<br/>only one upstream call in flight
+    B->>J: refresh T + client_secret (once)
+    J-->>B: rotated pair (old T invalidated)
+    B-->>C1: rotated pair
+    B-->>C2: same rotated pair (no 2nd upstream call)
+    Note over B: result cached in-memory for a short TTL (default 60s)
+```
 
 ### Security model
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/appleboy/go-jira
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0

--- a/pkg/auth/resolver.go
+++ b/pkg/auth/resolver.go
@@ -26,6 +26,12 @@ type Config struct {
 	OAuthRedirectURI string
 	OAuthScopes      []string
 
+	// BrokerURL / BrokerToken route the refresh through the token refresh broker
+	// when set, so the auto-refresh (401) and oauth-env paths use the broker too.
+	// Empty preserves the direct-refresh behaviour. login is unaffected.
+	BrokerURL   string
+	BrokerToken string
+
 	// OAuthHTTPClient, if set, is used for OAuth token endpoint requests
 	// (refresh / exchange) so they honour the same TLS behaviour as API calls —
 	// e.g. the --insecure client for self-signed Jira instances. nil lets
@@ -81,6 +87,8 @@ func oauthConfig(cfg Config) *oauth.Config {
 		RedirectURI: cfg.OAuthRedirectURI,
 		Scopes:      cfg.OAuthScopes,
 		HTTPClient:  cfg.OAuthHTTPClient,
+		BrokerURL:   cfg.BrokerURL,
+		BrokerToken: cfg.BrokerToken,
 	}
 }
 

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -376,12 +376,13 @@ func (c *resultCache) do(
 	fn func() (*oauth2.Token, error),
 ) (tok *oauth2.Token, executed bool, err error) {
 	c.mu.Lock()
-	c.evictExpiredLocked()
+	now := c.now()
+	c.evictExpiredLocked(now)
 	if r, ok := c.results[key]; ok {
 		// Per-key freshness check: the sweep above is amortized (runs at most
 		// once per TTL), so an entry may still be present past its TTL — never
 		// serve a stale result; drop it and fall through to a fresh refresh.
-		if c.now().Sub(r.fetchedAt) < c.ttl {
+		if !c.expired(now, r) {
 			c.mu.Unlock()
 			return r.tok, false, nil
 		}
@@ -430,7 +431,12 @@ func (c *resultCache) do(
 	return call.tok, true, call.err
 }
 
-// evictExpiredLocked reclaims results past their TTL. c.mu must be held.
+// expired reports whether a cached result is past its TTL as of now.
+func (c *resultCache) expired(now time.Time, r cachedResult) bool {
+	return now.Sub(r.fetchedAt) >= c.ttl
+}
+
+// evictExpiredLocked reclaims results past their TTL as of now. c.mu must be held.
 //
 // The sweep is amortized: it walks the whole map at most once per TTL window
 // (gated by lastSwept) rather than on every call, so the per-request hot path
@@ -439,14 +445,13 @@ func (c *resultCache) do(
 // keys) pay a full-map scan while holding the global lock. Correctness does not
 // depend on the sweep cadence: do()'s per-key freshness check never serves an
 // expired entry. Only reclamation of never-re-accessed keys relies on the sweep.
-func (c *resultCache) evictExpiredLocked() {
-	now := c.now()
+func (c *resultCache) evictExpiredLocked(now time.Time) {
 	if now.Sub(c.lastSwept) < c.ttl {
 		return
 	}
 	c.lastSwept = now
 	for k, r := range c.results {
-		if now.Sub(r.fetchedAt) >= c.ttl {
+		if c.expired(now, r) {
 			delete(c.results, k)
 		}
 	}

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -258,6 +258,12 @@ func (s *Server) callerAuthOK(r *http.Request) bool {
 
 func (s *Server) writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
+	// Refresh responses carry OAuth token material; per RFC 6749 §5.1 the token
+	// endpoint MUST forbid caching so no intermediary (reverse proxy, shared
+	// cache) retains a token-bearing body. writeJSON serves every /v1/refresh
+	// response (success and error), so setting it here covers them all.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		slog.Warn("broker: encode response", "error", err)

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -345,10 +345,12 @@ type inflightCall struct {
 
 // resultCache coalesces concurrent refreshes of the same key into one upstream
 // call and reuses a successful result for a short TTL. It is purely in-memory,
-// never persists, and lazily evicts expired entries on each access. Live memory
-// is therefore bounded by the number of distinct tokens seen within one TTL
+// never persists, and runs no background goroutine. Expired entries are reclaimed
+// two ways: a per-key freshness check on access (an expired hit is dropped and
+// treated as a miss) and an amortized full sweep that runs at most once per TTL
+// window. Live memory is bounded by the distinct tokens seen within ~one TTL
 // window (it can grow during a burst of distinct tokens, but every entry is
-// reclaimed once its TTL lapses), and it runs no background goroutine.
+// reclaimed within ~2×TTL).
 type resultCache struct {
 	ttl time.Duration
 	now func() time.Time
@@ -360,9 +362,10 @@ type resultCache struct {
 	// production.
 	onCoalesce func()
 
-	mu       sync.Mutex
-	results  map[string]cachedResult
-	inflight map[string]*inflightCall
+	mu        sync.Mutex
+	results   map[string]cachedResult
+	inflight  map[string]*inflightCall
+	lastSwept time.Time // time of the last full eviction sweep; gates evictExpiredLocked
 }
 
 // do returns a token for key, calling fn at most once across concurrent callers
@@ -375,8 +378,14 @@ func (c *resultCache) do(
 	c.mu.Lock()
 	c.evictExpiredLocked()
 	if r, ok := c.results[key]; ok {
-		c.mu.Unlock()
-		return r.tok, false, nil
+		// Per-key freshness check: the sweep above is amortized (runs at most
+		// once per TTL), so an entry may still be present past its TTL — never
+		// serve a stale result; drop it and fall through to a fresh refresh.
+		if c.now().Sub(r.fetchedAt) < c.ttl {
+			c.mu.Unlock()
+			return r.tok, false, nil
+		}
+		delete(c.results, key)
 	}
 	if call, ok := c.inflight[key]; ok {
 		c.mu.Unlock()
@@ -421,11 +430,21 @@ func (c *resultCache) do(
 	return call.tok, true, call.err
 }
 
-// evictExpiredLocked removes results past their TTL. c.mu must be held. Sweeping
-// the whole map on each access keeps it bounded by (request rate × TTL), which
-// is small, and avoids a background janitor goroutine.
+// evictExpiredLocked reclaims results past their TTL. c.mu must be held.
+//
+// The sweep is amortized: it walks the whole map at most once per TTL window
+// (gated by lastSwept) rather than on every call, so the per-request hot path
+// stays O(1) instead of O(len(results)) under the lock — otherwise a burst of
+// distinct tokens would make every later request (even cache hits for unrelated
+// keys) pay a full-map scan while holding the global lock. Correctness does not
+// depend on the sweep cadence: do()'s per-key freshness check never serves an
+// expired entry. Only reclamation of never-re-accessed keys relies on the sweep.
 func (c *resultCache) evictExpiredLocked() {
 	now := c.now()
+	if now.Sub(c.lastSwept) < c.ttl {
+		return
+	}
+	c.lastSwept = now
 	for k, r := range c.results {
 		if now.Sub(r.fetchedAt) >= c.ttl {
 			delete(c.results, k)

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -338,6 +338,13 @@ type resultCache struct {
 	ttl time.Duration
 	now func() time.Time
 
+	// onCoalesce, when non-nil, is invoked each time a caller joins an existing
+	// in-flight call (just before it waits). It is a test seam used to gate the
+	// executor until all waiters have provably coalesced, so concurrency tests are
+	// deterministic without a timing-based sleep; it is nil (and free) in
+	// production.
+	onCoalesce func()
+
 	mu       sync.Mutex
 	results  map[string]cachedResult
 	inflight map[string]*inflightCall
@@ -358,6 +365,9 @@ func (c *resultCache) do(
 	}
 	if call, ok := c.inflight[key]; ok {
 		c.mu.Unlock()
+		if c.onCoalesce != nil {
+			c.onCoalesce()
+		}
 		call.wg.Wait()
 		return call.tok, false, call.err
 	}

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -247,7 +247,13 @@ func (s *Server) callerAuthOK(r *http.Request) bool {
 		return false
 	}
 	got := strings.TrimPrefix(h, prefix)
-	return subtle.ConstantTimeCompare([]byte(got), []byte(s.callerToken)) == 1
+	// Hash both sides to a fixed length first: subtle.ConstantTimeCompare
+	// short-circuits when the byte-slice lengths differ, which would otherwise
+	// leak the token length via timing. SHA-256 makes both operands 32 bytes so
+	// the compare is genuinely length-independent.
+	gotSum := sha256.Sum256([]byte(got))
+	wantSum := sha256.Sum256([]byte(s.callerToken))
+	return subtle.ConstantTimeCompare(gotSum[:], wantSum[:]) == 1
 }
 
 func (s *Server) writeJSON(w http.ResponseWriter, status int, body any) {
@@ -318,8 +324,10 @@ type inflightCall struct {
 
 // resultCache coalesces concurrent refreshes of the same key into one upstream
 // call and reuses a successful result for a short TTL. It is purely in-memory,
-// never persists, and lazily evicts expired entries on each access so it cannot
-// leak memory or goroutines.
+// never persists, and lazily evicts expired entries on each access. Live memory
+// is therefore bounded by the number of distinct tokens seen within one TTL
+// window (it can grow during a burst of distinct tokens, but every entry is
+// reclaimed once its TTL lapses), and it runs no background goroutine.
 type resultCache struct {
 	ttl time.Duration
 	now func() time.Time

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -70,8 +70,11 @@ type Server struct {
 	refresh     RefreshFunc
 	clientID    string // when set, an incoming request's client_id must match it
 	callerToken string // optional caller bearer token; enforced only when non-empty
-	ready       func() error
-	cache       *resultCache
+	// callerTokenSum is sha256(callerToken), precomputed once so the per-request
+	// constant-time compare does not re-hash the (immutable) configured token.
+	callerTokenSum [32]byte
+	ready          func() error
+	cache          *resultCache
 
 	refreshSuccess      atomic.Int64
 	refreshError        atomic.Int64
@@ -103,10 +106,11 @@ func NewServer(opts Options) (*Server, error) {
 		return nil, errors.New("broker: Refresh function is required")
 	}
 	return &Server{
-		refresh:     opts.Refresh,
-		clientID:    opts.ClientID,
-		callerToken: opts.CallerToken,
-		ready:       opts.Ready,
+		refresh:        opts.Refresh,
+		clientID:       opts.ClientID,
+		callerToken:    opts.CallerToken,
+		callerTokenSum: sha256.Sum256([]byte(opts.CallerToken)),
+		ready:          opts.Ready,
 		cache: &resultCache{
 			ttl:      defaultCacheTTL,
 			now:      time.Now,
@@ -225,6 +229,17 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, status, code, "")
 		return
 	}
+	// A RefreshFunc must return a non-nil token on success. Guard the nil/nil case
+	// defensively so a misbehaving Refresh reports a server error instead of
+	// panicking tokenResponse here — which, via coalescing, would also take down
+	// every waiter sharing this key.
+	if tok == nil {
+		s.refreshError.Add(1)
+		slog.Warn("broker refresh returned no token and no error",
+			"key", keyPrefix, "executed", executed, "latency_ms", latencyMS(start))
+		s.writeError(w, http.StatusInternalServerError, codeServerError, "")
+		return
+	}
 
 	resp := tokenResponse(tok)
 	s.refreshSuccess.Add(1)
@@ -247,13 +262,13 @@ func (s *Server) callerAuthOK(r *http.Request) bool {
 		return false
 	}
 	got := strings.TrimPrefix(h, prefix)
-	// Hash both sides to a fixed length first: subtle.ConstantTimeCompare
+	// Hash the presented token to a fixed length: subtle.ConstantTimeCompare
 	// short-circuits when the byte-slice lengths differ, which would otherwise
 	// leak the token length via timing. SHA-256 makes both operands 32 bytes so
-	// the compare is genuinely length-independent.
+	// the compare is genuinely length-independent. The want side (callerTokenSum)
+	// is precomputed at construction since the configured token never changes.
 	gotSum := sha256.Sum256([]byte(got))
-	wantSum := sha256.Sum256([]byte(s.callerToken))
-	return subtle.ConstantTimeCompare(gotSum[:], wantSum[:]) == 1
+	return subtle.ConstantTimeCompare(gotSum[:], s.callerTokenSum[:]) == 1
 }
 
 func (s *Server) writeJSON(w http.ResponseWriter, status int, body any) {

--- a/pkg/broker/server.go
+++ b/pkg/broker/server.go
@@ -1,0 +1,395 @@
+package broker
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// defaultCacheTTL bounds how long a rotated token pair is reused for the same
+// refresh_token. It only needs to cover the brief window in which concurrent
+// callers race on one (about-to-be-invalidated) refresh_token; it is NOT a
+// general token cache. Kept short so a revoked token is not honoured for long.
+const defaultCacheTTL = 60 * time.Second
+
+// maxRequestBody caps the refresh request body to defend against oversized
+// payloads; a refresh_token is small.
+const maxRequestBody = 1 << 16 // 64 KiB
+
+// codeServerError is the OAuth2-style error code returned for an unexpected
+// (non-*APIError) failure.
+const codeServerError = "server_error"
+
+// RefreshFunc performs the secret-bearing refresh against Jira DC. The cmd layer
+// wires oauth.Config.Refresh into it and translates oauth's sentinel errors into
+// *APIError so the handler can pick the right HTTP status without this package
+// importing pkg/oauth (which would create an import cycle).
+type RefreshFunc func(ctx context.Context, refreshToken string) (*oauth2.Token, error)
+
+// APIError lets the RefreshFunc dictate the HTTP status and OAuth2 error code the
+// broker returns. A non-*APIError failure is reported as 500 server_error.
+type APIError struct {
+	Status int    // HTTP status to return
+	Code   string // OAuth2-style error code for the JSON body
+	Err    error  // underlying cause, for logging only (never sent to the client)
+}
+
+func (e *APIError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("broker: %s (status %d): %v", e.Code, e.Status, e.Err)
+	}
+	return fmt.Sprintf("broker: %s (status %d)", e.Code, e.Status)
+}
+
+func (e *APIError) Unwrap() error { return e.Err }
+
+// Metrics is a snapshot of the broker's counters, exposed for tests and
+// observability. Counters are cumulative since process start.
+type Metrics struct {
+	RefreshTotal  map[string]int64 // keyed by result: "success" | "error" | "unauthorized" | "bad_request"
+	UpstreamCalls int64            // actual refresh calls forwarded to Jira DC
+	CacheHits     int64            // requests served without an upstream call (TTL hit or coalesced)
+}
+
+// Server is the broker HTTP service. The zero value is not usable; construct it
+// with NewServer.
+type Server struct {
+	refresh     RefreshFunc
+	clientID    string // when set, an incoming request's client_id must match it
+	callerToken string // optional caller bearer token; enforced only when non-empty
+	ready       func() error
+	cache       *resultCache
+
+	refreshSuccess      atomic.Int64
+	refreshError        atomic.Int64
+	refreshUnauthorized atomic.Int64
+	refreshBadRequest   atomic.Int64
+	upstreamCalls       atomic.Int64
+	cacheHits           atomic.Int64
+}
+
+// Options configures a Server.
+type Options struct {
+	// Refresh performs the upstream refresh (required).
+	Refresh RefreshFunc
+	// ClientID, when set, is matched against a request's optional client_id; a
+	// mismatch is rejected with 400. Empty disables the check.
+	ClientID string
+	// CallerToken, when set, is the bearer token callers must present. Empty
+	// disables caller-token auth entirely (network-layer controls are the
+	// primary defence — see the package and plan docs).
+	CallerToken string
+	// Ready, when set, is called by /readyz; a non-nil error reports not-ready.
+	Ready func() error
+}
+
+// NewServer builds a Server from opts. Refresh must be non-nil. Logging goes to
+// the slog default (configured by the CLI's setupLogging).
+func NewServer(opts Options) (*Server, error) {
+	if opts.Refresh == nil {
+		return nil, errors.New("broker: Refresh function is required")
+	}
+	return &Server{
+		refresh:     opts.Refresh,
+		clientID:    opts.ClientID,
+		callerToken: opts.CallerToken,
+		ready:       opts.Ready,
+		cache: &resultCache{
+			ttl:      defaultCacheTTL,
+			now:      time.Now,
+			results:  map[string]cachedResult{},
+			inflight: map[string]*inflightCall{},
+		},
+	}, nil
+}
+
+// Handler returns the broker's HTTP handler with all routes registered.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(RefreshPath, s.handleRefresh)
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/readyz", s.handleReadyz)
+	return mux
+}
+
+// Metrics returns a snapshot of the broker's counters.
+func (s *Server) Metrics() Metrics {
+	return Metrics{
+		RefreshTotal: map[string]int64{
+			"success":      s.refreshSuccess.Load(),
+			"error":        s.refreshError.Load(),
+			"unauthorized": s.refreshUnauthorized.Load(),
+			"bad_request":  s.refreshBadRequest.Load(),
+		},
+		UpstreamCalls: s.upstreamCalls.Load(),
+		CacheHits:     s.cacheHits.Load(),
+	}
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	// Liveness must never touch the secret or upstream; always 200 if the
+	// process is serving.
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "ok\n")
+}
+
+func (s *Server) handleReadyz(w http.ResponseWriter, _ *http.Request) {
+	if s.ready != nil {
+		if err := s.ready(); err != nil {
+			slog.Warn("broker not ready", "error", err)
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "ready\n")
+}
+
+func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		s.writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "")
+		return
+	}
+
+	// Caller authentication (defence in depth; primary control is network-layer).
+	// Enforced only when a caller token is configured. Constant-time compare.
+	if !s.callerAuthOK(r) {
+		s.refreshUnauthorized.Add(1)
+		slog.Warn("broker refresh rejected: caller auth failed",
+			"latency_ms", latencyMS(start))
+		s.writeError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	var req RefreshRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBody)).Decode(&req); err != nil {
+		s.refreshBadRequest.Add(1)
+		s.writeError(w, http.StatusBadRequest, "invalid_request", "malformed JSON body")
+		return
+	}
+	if req.RefreshToken == "" {
+		s.refreshBadRequest.Add(1)
+		s.writeError(w, http.StatusBadRequest, "invalid_request", "refresh_token is required")
+		return
+	}
+	// Optional client_id check: reject a client pointed at the wrong broker.
+	if req.ClientID != "" && s.clientID != "" && req.ClientID != s.clientID {
+		s.refreshBadRequest.Add(1)
+		s.writeError(w, http.StatusBadRequest, "invalid_client_id",
+			"client_id does not match this broker")
+		return
+	}
+
+	// Hash the token once: the full hash is the cache/coalescing key, and a short
+	// prefix correlates logs without revealing the token.
+	key := keyFor(req.RefreshToken)
+	keyPrefix := key[:12]
+	// The shared upstream call is detached from this request's cancellation: when
+	// callers coalesce, the executor's disconnect must not abort the one upstream
+	// refresh that every waiter depends on. The HTTP client's own timeout still
+	// bounds it. Request values (if any) are preserved.
+	refreshCtx := context.WithoutCancel(r.Context())
+	tok, executed, err := s.cache.do(key, func() (*oauth2.Token, error) {
+		return s.refresh(refreshCtx, req.RefreshToken)
+	})
+	switch {
+	case executed:
+		s.upstreamCalls.Add(1)
+	case err == nil:
+		// Served without an upstream call (TTL hit or coalesced success). A
+		// coalesced *failure* is counted only as an error below, not a cache hit.
+		s.cacheHits.Add(1)
+	}
+
+	if err != nil {
+		s.refreshError.Add(1)
+		status, code := classifyRefreshError(err)
+		slog.Warn("broker refresh failed",
+			"key", keyPrefix, "executed", executed, "status", status,
+			"code", code, "latency_ms", latencyMS(start), "error", err)
+		s.writeError(w, status, code, "")
+		return
+	}
+
+	resp := tokenResponse(tok)
+	s.refreshSuccess.Add(1)
+	slog.Info("broker refresh ok",
+		"key", keyPrefix, "executed", executed, "status", http.StatusOK,
+		"latency_ms", latencyMS(start))
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// callerAuthOK reports whether the request carries the configured caller token.
+// When no caller token is configured the check is disabled and always passes
+// (the primary control is the network layer; see the package docs).
+func (s *Server) callerAuthOK(r *http.Request) bool {
+	if s.callerToken == "" {
+		return true
+	}
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return false
+	}
+	got := strings.TrimPrefix(h, prefix)
+	return subtle.ConstantTimeCompare([]byte(got), []byte(s.callerToken)) == 1
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		slog.Warn("broker: encode response", "error", err)
+	}
+}
+
+func (s *Server) writeError(w http.ResponseWriter, status int, code, desc string) {
+	s.writeJSON(w, status, ErrorResponse{Error: code, ErrorDescription: desc})
+}
+
+// classifyRefreshError extracts the HTTP status and OAuth2 error code from an
+// *APIError, defaulting to 500 server_error for any other failure.
+func classifyRefreshError(err error) (int, string) {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Status, apiErr.Code
+	}
+	return http.StatusInternalServerError, codeServerError
+}
+
+// tokenResponse builds the wire response from a token, recomputing expires_in
+// from the token's absolute expiry so a cache-served token reports its true
+// remaining lifetime rather than its original (now-stale) one.
+func tokenResponse(tok *oauth2.Token) TokenResponse {
+	resp := TokenResponse{
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		TokenType:    tok.TokenType,
+	}
+	if !tok.Expiry.IsZero() {
+		if rem := int64(time.Until(tok.Expiry).Seconds()); rem > 0 {
+			resp.ExpiresIn = rem
+		}
+	}
+	if scope, ok := tok.Extra("scope").(string); ok {
+		resp.Scope = scope
+	}
+	return resp
+}
+
+func latencyMS(start time.Time) int64 {
+	return time.Since(start).Milliseconds()
+}
+
+// keyFor derives the cache/coalescing key from the refresh token. The full
+// sha256 is the key; the plaintext token is never stored or logged.
+func keyFor(refreshToken string) string {
+	sum := sha256.Sum256([]byte(refreshToken))
+	return hex.EncodeToString(sum[:])
+}
+
+// --- result cache + per-key request coalescing ("singleflight") ---
+
+type cachedResult struct {
+	tok       *oauth2.Token
+	fetchedAt time.Time
+}
+
+type inflightCall struct {
+	wg  sync.WaitGroup
+	tok *oauth2.Token
+	err error
+}
+
+// resultCache coalesces concurrent refreshes of the same key into one upstream
+// call and reuses a successful result for a short TTL. It is purely in-memory,
+// never persists, and lazily evicts expired entries on each access so it cannot
+// leak memory or goroutines.
+type resultCache struct {
+	ttl time.Duration
+	now func() time.Time
+
+	mu       sync.Mutex
+	results  map[string]cachedResult
+	inflight map[string]*inflightCall
+}
+
+// do returns a token for key, calling fn at most once across concurrent callers
+// of the same key and reusing a fresh cached result. executed is true only for
+// the caller that actually invoked fn (i.e. made the upstream call).
+func (c *resultCache) do(
+	key string,
+	fn func() (*oauth2.Token, error),
+) (tok *oauth2.Token, executed bool, err error) {
+	c.mu.Lock()
+	c.evictExpiredLocked()
+	if r, ok := c.results[key]; ok {
+		c.mu.Unlock()
+		return r.tok, false, nil
+	}
+	if call, ok := c.inflight[key]; ok {
+		c.mu.Unlock()
+		call.wg.Wait()
+		return call.tok, false, call.err
+	}
+	call := &inflightCall{}
+	call.wg.Add(1)
+	c.inflight[key] = call
+	c.mu.Unlock()
+
+	executed = true
+	// The cleanup runs via defer so the inflight entry is always cleared and
+	// waiters are always released — even if fn panics. Otherwise a single panic
+	// would wedge this key forever and leak every coalesced (and future) waiter.
+	// A recovered panic becomes call.err so waiters get a real error, not a nil
+	// token that would nil-deref downstream.
+	defer func() {
+		if r := recover(); r != nil && call.err == nil {
+			call.err = fmt.Errorf("broker: refresh panicked: %v", r)
+		}
+		c.mu.Lock()
+		delete(c.inflight, key)
+		// Only successful results are cached; a failure must not be served to the
+		// next caller (e.g. a transient upstream error should be retried).
+		if call.err == nil && call.tok != nil {
+			c.results[key] = cachedResult{tok: call.tok, fetchedAt: c.now()}
+		}
+		c.mu.Unlock()
+		call.wg.Done()
+		// Propagate the result to this (executor) caller's named returns, covering
+		// the panic path where the explicit return below never ran.
+		tok, err = call.tok, call.err
+	}()
+
+	// Upstream call runs OUTSIDE the lock so other keys are not blocked; callers
+	// of the SAME key wait on call.wg above.
+	call.tok, call.err = fn()
+	return call.tok, true, call.err
+}
+
+// evictExpiredLocked removes results past their TTL. c.mu must be held. Sweeping
+// the whole map on each access keeps it bounded by (request rate × TTL), which
+// is small, and avoids a background janitor goroutine.
+func (c *resultCache) evictExpiredLocked() {
+	now := c.now()
+	for k, r := range c.results {
+		if now.Sub(r.fetchedAt) >= c.ttl {
+			delete(c.results, k)
+		}
+	}
+}

--- a/pkg/broker/server_test.go
+++ b/pkg/broker/server_test.go
@@ -268,6 +268,13 @@ func TestHealthzReadyz(t *testing.T) {
 // exactly one caller reported as having executed it.
 func TestResultCacheCoalesces(t *testing.T) {
 	c := newResultCache(time.Minute, time.Now)
+	const n = 10
+	// Gate the executor on all other callers provably coalescing as in-flight
+	// waiters, so the test is deterministic without a timing-based sleep.
+	var coalesced sync.WaitGroup
+	coalesced.Add(n - 1)
+	c.onCoalesce = coalesced.Done
+
 	var calls atomic.Int64
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
@@ -281,7 +288,6 @@ func TestResultCacheCoalesces(t *testing.T) {
 		return &oauth2.Token{AccessToken: "a"}, nil
 	}
 
-	const n = 10
 	var wg sync.WaitGroup
 	tokens := make([]*oauth2.Token, n)
 	executed := make([]bool, n)
@@ -297,11 +303,9 @@ func TestResultCacheCoalesces(t *testing.T) {
 		}(i)
 	}
 
-	<-started
-	// Give the other goroutines time to register as inflight waiters before the
-	// single executor completes.
-	time.Sleep(100 * time.Millisecond)
-	close(release)
+	<-started        // the single executor is now in fn
+	coalesced.Wait() // every other caller has joined as an in-flight waiter
+	close(release)   // let the executor finish
 	wg.Wait()
 
 	if calls.Load() != 1 {
@@ -356,6 +360,11 @@ func TestResultCacheTTLEviction(t *testing.T) {
 // a subsequent call for the same key can execute again.
 func TestResultCachePanicReleasesWaiters(t *testing.T) {
 	c := newResultCache(time.Minute, time.Now)
+	const n = 5
+	var coalesced sync.WaitGroup
+	coalesced.Add(n - 1)
+	c.onCoalesce = coalesced.Done
+
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
 	panicFn := func() (*oauth2.Token, error) {
@@ -367,7 +376,6 @@ func TestResultCachePanicReleasesWaiters(t *testing.T) {
 		panic("boom")
 	}
 
-	const n = 5
 	var wg sync.WaitGroup
 	errs := make([]error, n)
 	for i := range n {
@@ -378,8 +386,8 @@ func TestResultCachePanicReleasesWaiters(t *testing.T) {
 		}(i)
 	}
 
-	<-started
-	time.Sleep(100 * time.Millisecond) // let the rest coalesce as waiters
+	<-started        // the single executor is now in panicFn
+	coalesced.Wait() // the rest have joined as in-flight waiters
 	close(release)
 	wg.Wait() // must not hang
 
@@ -403,6 +411,7 @@ func TestResultCachePanicReleasesWaiters(t *testing.T) {
 // once, the failure is not counted as a cache hit, and every caller is counted
 // as an error.
 func TestRefreshCoalescedFailureMetrics(t *testing.T) {
+	const n = 6
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
 	var upstream atomic.Int64
@@ -417,8 +426,13 @@ func TestRefreshCoalescedFailureMetrics(t *testing.T) {
 			return nil, &APIError{Status: http.StatusServiceUnavailable, Code: codeServerError}
 		},
 	})
+	// Gate the executor on all other callers coalescing. A coalesced FAILURE is
+	// never cached, so without this barrier a straggler that arrived after the
+	// executor returned could start a second upstream call.
+	var coalesced sync.WaitGroup
+	coalesced.Add(n - 1)
+	s.cache.onCoalesce = coalesced.Done
 
-	const n = 6
 	var wg sync.WaitGroup
 	for range n {
 		wg.Add(1)
@@ -428,8 +442,8 @@ func TestRefreshCoalescedFailureMetrics(t *testing.T) {
 		}()
 	}
 
-	<-started
-	time.Sleep(100 * time.Millisecond)
+	<-started        // the single executor has reached the upstream call
+	coalesced.Wait() // every other caller has coalesced onto it
 	close(release)
 	wg.Wait()
 

--- a/pkg/broker/server_test.go
+++ b/pkg/broker/server_test.go
@@ -355,6 +355,42 @@ func TestResultCacheTTLEviction(t *testing.T) {
 	}
 }
 
+// TestResultCacheLazyFreshnessCheck verifies an entry past its TTL is never
+// served even when the amortized full sweep is skipped — eviction was made
+// amortized (at most once per TTL) so the hot path no longer scans the whole
+// map per request, leaving the per-key freshness check as the correctness anchor.
+func TestResultCacheLazyFreshnessCheck(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := newResultCache(60*time.Second, func() time.Time { return now })
+	var calls atomic.Int64
+	fn := func() (*oauth2.Token, error) {
+		calls.Add(1)
+		return &oauth2.Token{AccessToken: "a"}, nil
+	}
+
+	// Prime the cache: caches k@1000 and this call's sweep sets lastSwept=1000.
+	if _, executed, _ := c.do("k", fn); !executed {
+		t.Fatal("first call should execute fn")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+
+	// Move past k's TTL, but pin lastSwept to now so the amortized sweep returns
+	// early: only the per-key freshness check can catch the stale entry now.
+	now = now.Add(61 * time.Second) // k is now 61s old (expired)
+	c.mu.Lock()
+	c.lastSwept = now
+	c.mu.Unlock()
+
+	if _, executed, _ := c.do("k", fn); !executed {
+		t.Fatal("expired entry must be re-fetched even when the full sweep is skipped")
+	}
+	if calls.Load() != 2 {
+		t.Errorf("calls = %d, want 2 (a stale entry must not be served)", calls.Load())
+	}
+}
+
 // TestResultCachePanicReleasesWaiters verifies that a panic in fn does not
 // deadlock coalesced waiters or wedge the key: all callers receive an error and
 // a subsequent call for the same key can execute again.

--- a/pkg/broker/server_test.go
+++ b/pkg/broker/server_test.go
@@ -1,0 +1,460 @@
+package broker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// okRefresh returns a static rotated token. Used where the refresh result is not
+// the thing under test.
+func okRefresh(_ context.Context, _ string) (*oauth2.Token, error) {
+	return &oauth2.Token{
+		AccessToken:  "access-new",
+		RefreshToken: "refresh-new",
+		TokenType:    "bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}, nil
+}
+
+func newTestServer(t *testing.T, opts Options) *Server {
+	t.Helper()
+	if opts.Refresh == nil {
+		opts.Refresh = okRefresh
+	}
+	s, err := NewServer(opts)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return s
+}
+
+// postRefresh issues a POST /v1/refresh against the server's handler and returns
+// the recorder.
+func postRefresh(s *Server, body any, authz string) *httptest.ResponseRecorder {
+	payload, _ := json.Marshal(body)
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPost, RefreshPath, bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	if authz != "" {
+		req.Header.Set("Authorization", authz)
+	}
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeErr(t *testing.T, rec *httptest.ResponseRecorder) ErrorResponse {
+	t.Helper()
+	var er ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &er); err != nil {
+		t.Fatalf("decode error body %q: %v", rec.Body.String(), err)
+	}
+	return er
+}
+
+func TestNewServerRequiresRefresh(t *testing.T) {
+	if _, err := NewServer(Options{}); err == nil {
+		t.Fatal("NewServer with nil Refresh should error")
+	}
+}
+
+func TestRefreshHappyPath(t *testing.T) {
+	s := newTestServer(t, Options{})
+	rec := postRefresh(s, RefreshRequest{RefreshToken: "old"}, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	var tr TokenResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &tr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if tr.AccessToken != "access-new" || tr.RefreshToken != "refresh-new" {
+		t.Errorf("token response = %+v, want rotated pair", tr)
+	}
+	if tr.ExpiresIn <= 0 {
+		t.Errorf("expires_in = %d, want > 0", tr.ExpiresIn)
+	}
+	if m := s.Metrics(); m.RefreshTotal["success"] != 1 || m.UpstreamCalls != 1 {
+		t.Errorf("metrics = %+v, want 1 success / 1 upstream", m)
+	}
+}
+
+func TestRefreshMethodNotAllowed(t *testing.T) {
+	s := newTestServer(t, Options{})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, RefreshPath, nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestRefreshBadRequest(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"malformed", "{not json"},
+		{"missing refresh_token", `{}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstream atomic.Int64
+			s := newTestServer(
+				t,
+				Options{Refresh: func(_ context.Context, _ string) (*oauth2.Token, error) {
+					upstream.Add(1)
+					return okRefresh(context.Background(), "")
+				}},
+			)
+			req := httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodPost,
+				RefreshPath,
+				bytes.NewReader([]byte(tc.body)),
+			)
+			rec := httptest.NewRecorder()
+			s.Handler().ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+			if upstream.Load() != 0 {
+				t.Errorf("upstream called %d times, want 0 on bad request", upstream.Load())
+			}
+		})
+	}
+}
+
+func TestRefreshClientIDMismatch(t *testing.T) {
+	var upstream atomic.Int64
+	s := newTestServer(t, Options{
+		ClientID: "client-abc",
+		Refresh: func(_ context.Context, _ string) (*oauth2.Token, error) {
+			upstream.Add(1)
+			return okRefresh(context.Background(), "")
+		},
+	})
+	rec := postRefresh(s, RefreshRequest{RefreshToken: "old", ClientID: "wrong"}, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if upstream.Load() != 0 {
+		t.Errorf("upstream called on client_id mismatch, want 0")
+	}
+}
+
+func TestRefreshCallerAuth(t *testing.T) {
+	var upstream atomic.Int64
+	refresh := func(_ context.Context, _ string) (*oauth2.Token, error) {
+		upstream.Add(1)
+		return okRefresh(context.Background(), "")
+	}
+	s := newTestServer(t, Options{CallerToken: "broker-secret", Refresh: refresh})
+
+	// Missing token → 401, no upstream call.
+	rec := postRefresh(s, RefreshRequest{RefreshToken: "old"}, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token: status = %d, want 401", rec.Code)
+	}
+	// Wrong token → 401.
+	rec = postRefresh(s, RefreshRequest{RefreshToken: "old"}, "Bearer nope")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token: status = %d, want 401", rec.Code)
+	}
+	if upstream.Load() != 0 {
+		t.Fatalf("upstream called %d times on auth failure, want 0", upstream.Load())
+	}
+	if m := s.Metrics(); m.RefreshTotal["unauthorized"] != 2 {
+		t.Errorf("unauthorized metric = %d, want 2", m.RefreshTotal["unauthorized"])
+	}
+
+	// Correct token → 200, one upstream call.
+	rec = postRefresh(s, RefreshRequest{RefreshToken: "old"}, "Bearer broker-secret")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correct token: status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if upstream.Load() != 1 {
+		t.Errorf("upstream called %d times, want 1", upstream.Load())
+	}
+}
+
+func TestRefreshErrorMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			"invalid_grant",
+			&APIError{Status: http.StatusBadRequest, Code: "invalid_grant"},
+			http.StatusBadRequest,
+			"invalid_grant",
+		},
+		{
+			"invalid_client",
+			&APIError{Status: http.StatusBadGateway, Code: "invalid_client"},
+			http.StatusBadGateway,
+			"invalid_client",
+		},
+		{
+			"upstream",
+			&APIError{Status: http.StatusServiceUnavailable, Code: "server_error"},
+			http.StatusServiceUnavailable,
+			"server_error",
+		},
+		{
+			"unexpected non-APIError",
+			io.ErrUnexpectedEOF,
+			http.StatusInternalServerError,
+			"server_error",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer(
+				t,
+				Options{Refresh: func(_ context.Context, _ string) (*oauth2.Token, error) {
+					return nil, tc.err
+				}},
+			)
+			rec := postRefresh(s, RefreshRequest{RefreshToken: "old"}, "")
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if er := decodeErr(t, rec); er.Error != tc.wantCode {
+				t.Errorf("error code = %q, want %q", er.Error, tc.wantCode)
+			}
+			if m := s.Metrics(); m.RefreshTotal["error"] != 1 {
+				t.Errorf("error metric = %d, want 1", m.RefreshTotal["error"])
+			}
+		})
+	}
+}
+
+func TestHealthzReadyz(t *testing.T) {
+	s := newTestServer(t, Options{Ready: func() error { return nil }})
+	for _, path := range []string{"/healthz", "/readyz"} {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s status = %d, want 200", path, rec.Code)
+		}
+	}
+
+	// readyz reports 503 when the readiness check fails.
+	notReady := newTestServer(t, Options{Ready: func() error { return io.ErrUnexpectedEOF }})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	notReady.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("readyz (not ready) status = %d, want 503", rec.Code)
+	}
+}
+
+// TestResultCacheCoalesces verifies that concurrent calls for the same key
+// collapse into a single upstream call and all receive the same result, with
+// exactly one caller reported as having executed it.
+func TestResultCacheCoalesces(t *testing.T) {
+	c := newResultCache(time.Minute, time.Now)
+	var calls atomic.Int64
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	fn := func() (*oauth2.Token, error) {
+		calls.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		return &oauth2.Token{AccessToken: "a"}, nil
+	}
+
+	const n = 10
+	var wg sync.WaitGroup
+	tokens := make([]*oauth2.Token, n)
+	executed := make([]bool, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tok, ex, err := c.do("k", fn)
+			if err != nil {
+				t.Errorf("do: %v", err)
+			}
+			tokens[i], executed[i] = tok, ex
+		}(i)
+	}
+
+	<-started
+	// Give the other goroutines time to register as inflight waiters before the
+	// single executor completes.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if calls.Load() != 1 {
+		t.Errorf("upstream calls = %d, want 1", calls.Load())
+	}
+	executedCount := 0
+	for i := range n {
+		if executed[i] {
+			executedCount++
+		}
+		if tokens[i] == nil || tokens[i].AccessToken != "a" {
+			t.Errorf("caller %d token = %+v, want access 'a'", i, tokens[i])
+		}
+	}
+	if executedCount != 1 {
+		t.Errorf("executed count = %d, want exactly 1", executedCount)
+	}
+}
+
+// TestResultCacheTTLEviction verifies a result is reused within the TTL and a
+// fresh upstream call happens once it expires.
+func TestResultCacheTTLEviction(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := newResultCache(60*time.Second, func() time.Time { return now })
+	var calls atomic.Int64
+	fn := func() (*oauth2.Token, error) {
+		calls.Add(1)
+		return &oauth2.Token{AccessToken: "a"}, nil
+	}
+
+	if _, executed, _ := c.do("k", fn); !executed {
+		t.Error("first call should execute fn")
+	}
+	if _, executed, _ := c.do("k", fn); executed {
+		t.Error("second call within TTL should be served from cache")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d within TTL, want 1", calls.Load())
+	}
+
+	now = now.Add(61 * time.Second) // past TTL
+	if _, executed, _ := c.do("k", fn); !executed {
+		t.Error("call after TTL should execute fn again")
+	}
+	if calls.Load() != 2 {
+		t.Errorf("calls = %d after TTL, want 2", calls.Load())
+	}
+}
+
+// TestResultCachePanicReleasesWaiters verifies that a panic in fn does not
+// deadlock coalesced waiters or wedge the key: all callers receive an error and
+// a subsequent call for the same key can execute again.
+func TestResultCachePanicReleasesWaiters(t *testing.T) {
+	c := newResultCache(time.Minute, time.Now)
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	panicFn := func() (*oauth2.Token, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		panic("boom")
+	}
+
+	const n = 5
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _, errs[i] = c.do("k", panicFn)
+		}(i)
+	}
+
+	<-started
+	time.Sleep(100 * time.Millisecond) // let the rest coalesce as waiters
+	close(release)
+	wg.Wait() // must not hang
+
+	for i := range n {
+		if errs[i] == nil {
+			t.Errorf("caller %d got nil error, want the recovered panic error", i)
+		}
+	}
+
+	// The key must not be wedged: a fresh call executes a healthy fn.
+	tok, executed, err := c.do("k", func() (*oauth2.Token, error) {
+		return &oauth2.Token{AccessToken: "a"}, nil
+	})
+	if err != nil || tok == nil || !executed {
+		t.Fatalf("key wedged after panic: tok=%v executed=%v err=%v", tok, executed, err)
+	}
+}
+
+// TestRefreshCoalescedFailureMetrics verifies that when concurrent same-token
+// refreshes coalesce onto a single FAILED upstream call, the upstream is hit
+// once, the failure is not counted as a cache hit, and every caller is counted
+// as an error.
+func TestRefreshCoalescedFailureMetrics(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	var upstream atomic.Int64
+	s := newTestServer(t, Options{
+		Refresh: func(_ context.Context, _ string) (*oauth2.Token, error) {
+			upstream.Add(1)
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil, &APIError{Status: http.StatusServiceUnavailable, Code: codeServerError}
+		},
+	})
+
+	const n = 6
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			postRefresh(s, RefreshRequest{RefreshToken: "old"}, "")
+		}()
+	}
+
+	<-started
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	m := s.Metrics()
+	if upstream.Load() != 1 {
+		t.Errorf("upstream calls = %d, want 1 (coalesced)", upstream.Load())
+	}
+	if m.UpstreamCalls != 1 {
+		t.Errorf("UpstreamCalls = %d, want 1", m.UpstreamCalls)
+	}
+	if m.CacheHits != 0 {
+		t.Errorf("CacheHits = %d, want 0 (coalesced failures are not cache hits)", m.CacheHits)
+	}
+	if m.RefreshTotal["error"] != n {
+		t.Errorf("error metric = %d, want %d", m.RefreshTotal["error"], n)
+	}
+}
+
+// newResultCache is a small test constructor mirroring the inline construction
+// in NewServer.
+func newResultCache(ttl time.Duration, now func() time.Time) *resultCache {
+	return &resultCache{
+		ttl:      ttl,
+		now:      now,
+		results:  map[string]cachedResult{},
+		inflight: map[string]*inflightCall{},
+	}
+}

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -1,0 +1,56 @@
+// Package broker implements the server side of the OAuth token refresh broker.
+//
+// MediaTek's internal Jira DC OAuth application is a confidential client: its
+// token endpoint requires a client_secret on the grant_type=refresh_token step.
+// go-jira ships as a public PKCE client and must never embed that secret (a
+// published binary would expose it). The broker is a small server-side service
+// that holds the client_secret and performs only the secret-bearing refresh
+// step on a client's behalf: the CLI sends its refresh_token, the broker adds
+// the client_secret, forwards to Jira DC, and returns the rotated token pair.
+//
+// The broker never stores any token. It keeps only a short-TTL in-memory result
+// cache (with per-key request coalescing) to absorb the refresh-token rotation
+// race Jira DC creates — a successful refresh invalidates the old refresh_token,
+// so concurrent refreshes of the same token must collapse to a single upstream
+// call and share the one rotated pair.
+//
+// This package deliberately does NOT import pkg/oauth. The refresh itself is
+// supplied as a RefreshFunc so the only component that holds the secret and
+// talks to Jira (pkg/oauth via the cmd wiring) stays in one place and there is
+// no import cycle with pkg/oauth's client-side broker caller.
+package broker
+
+// RefreshPath is the broker's refresh endpoint path. The client appends it to
+// the configured broker base URL; the server registers it on its mux.
+const RefreshPath = "/v1/refresh"
+
+// RefreshRequest is the JSON body of POST /v1/refresh.
+//
+// The broker uses its OWN configured base URL / client_id / client_secret; it
+// never accepts an upstream endpoint from the caller. ClientID is optional: when
+// present the broker verifies it matches its own client and rejects a mismatch,
+// catching a client pointed at the wrong broker.
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+	ClientID     string `json:"client_id,omitempty"`
+}
+
+// TokenResponse is the success body of POST /v1/refresh. It mirrors the standard
+// OAuth2 token response shape so the client maps it onto an *oauth2.Token with
+// minimal effort. ExpiresIn is recomputed per response from the cached token's
+// absolute expiry, so a cache-served token reports its true remaining lifetime.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// ErrorResponse is the JSON error body, using OAuth2-style error codes so the
+// client can map them back to its existing sentinel errors (e.g. invalid_grant
+// → "run `go-jira login` again").
+type ErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -1,18 +1,18 @@
 // Package broker implements the server side of the OAuth token refresh broker.
 //
-// MediaTek's internal Jira DC OAuth application is a confidential client: its
-// token endpoint requires a client_secret on the grant_type=refresh_token step.
-// go-jira ships as a public PKCE client and must never embed that secret (a
-// published binary would expose it). The broker is a small server-side service
-// that holds the client_secret and performs only the secret-bearing refresh
-// step on a client's behalf: the CLI sends its refresh_token, the broker adds
-// the client_secret, forwards to Jira DC, and returns the rotated token pair.
+// Some Jira DC OAuth applications are confidential clients: their token endpoint
+// requires a client_secret on the grant_type=refresh_token step. go-jira ships
+// as a public PKCE client and must never embed that secret (a published binary
+// would expose it). The broker is a small server-side service that holds the
+// client_secret and performs only the secret-bearing refresh step on a client's
+// behalf: the CLI sends its refresh_token, the broker adds the client_secret,
+// forwards to Jira DC, and returns the rotated token pair.
 //
-// The broker never stores any token. It keeps only a short-TTL in-memory result
-// cache (with per-key request coalescing) to absorb the refresh-token rotation
-// race Jira DC creates — a successful refresh invalidates the old refresh_token,
-// so concurrent refreshes of the same token must collapse to a single upstream
-// call and share the one rotated pair.
+// The broker does not persist tokens at rest. It keeps only a short-TTL
+// in-memory result cache (with per-key request coalescing) to absorb the
+// refresh-token rotation race Jira DC creates — a successful refresh
+// invalidates the old refresh_token, so concurrent refreshes of the same token
+// must collapse to a single upstream call and share the one rotated pair.
 //
 // This package deliberately does NOT import pkg/oauth. The refresh itself is
 // supplied as a RefreshFunc so the only component that holds the secret and

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -121,14 +121,13 @@ func mapBrokerError(status int, body []byte) error {
 			// matching errors.Is(ErrInvalidGrant).
 			return wrapWithDesc(ErrInvalidGrant, er.ErrorDescription)
 		}
-		// Omit the description when absent so the message doesn't end with a
-		// dangling ": " (matching the wrapWithDesc hygiene above).
-		if er.ErrorDescription == "" {
-			return fmt.Errorf("oauth: broker rejected the request (%s)",
-				brokerErrCode(er, status))
+		// Append the description only when present so the message never ends
+		// with a dangling ": " (matching the wrapWithDesc hygiene above).
+		msg := fmt.Sprintf("oauth: broker rejected the request (%s)", brokerErrCode(er, status))
+		if er.ErrorDescription != "" {
+			msg += ": " + er.ErrorDescription
 		}
-		return fmt.Errorf("oauth: broker rejected the request (%s): %s",
-			brokerErrCode(er, status), er.ErrorDescription)
+		return errors.New(msg)
 	case http.StatusUnauthorized:
 		return fmt.Errorf("%w (status 401); set or correct the broker token",
 			ErrBrokerUnauthorized)

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -1,0 +1,133 @@
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/appleboy/go-jira/pkg/broker"
+
+	"golang.org/x/oauth2"
+)
+
+// maxBrokerResponse caps how much of the broker response body is read, both for
+// success and error bodies; the JSON token/error payloads are small.
+const maxBrokerResponse = 1 << 20 // 1 MiB
+
+// refreshViaBroker performs the refresh through the token refresh broker instead
+// of calling Jira DC directly. The client never holds the client_secret: it
+// sends only its refresh_token (and, optionally, its bearer token), and the
+// broker adds the secret upstream and returns the rotated pair.
+//
+// Broker responses are mapped back to this package's sentinel errors so the
+// auto-refresh path and the CLI's recovery hints behave identically to the
+// direct path (e.g. invalid_grant still tells the user to run `go-jira login`).
+func (c *Config) refreshViaBroker(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
+	//nolint:gosec // G117: serialising the refresh token is this function's
+	// purpose — it is the payload the broker needs to perform the refresh.
+	payload, err := json.Marshal(broker.RefreshRequest{
+		RefreshToken: refreshToken,
+		ClientID:     c.ClientID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("oauth: marshal broker request: %w", err)
+	}
+
+	url := strings.TrimRight(c.BrokerURL, "/") + broker.RefreshPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("oauth: build broker request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.BrokerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BrokerToken)
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		// A transport-level failure (DNS, connection refused, timeout) is an
+		// upstream/availability problem, not a credential one.
+		return nil, fmt.Errorf("%w: broker request failed: %v", ErrServerError, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBrokerResponse))
+
+	if resp.StatusCode == http.StatusOK {
+		var tr broker.TokenResponse
+		if err := json.Unmarshal(body, &tr); err != nil {
+			return nil, fmt.Errorf("oauth: decode broker response: %w", err)
+		}
+		if tr.AccessToken == "" {
+			return nil, errors.New("oauth: broker returned an empty access token")
+		}
+		return brokerTokenToOAuth2(tr, time.Now()), nil
+	}
+	return nil, mapBrokerError(resp.StatusCode, body)
+}
+
+// brokerTokenToOAuth2 converts the broker's wire response into an *oauth2.Token,
+// reconstructing the absolute expiry from the relative expires_in so callers
+// (storage.NewStoredToken) record the correct expiry and rotated refresh token.
+func brokerTokenToOAuth2(tr broker.TokenResponse, now time.Time) *oauth2.Token {
+	tok := &oauth2.Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		TokenType:    tr.TokenType,
+	}
+	if tr.ExpiresIn > 0 {
+		tok.Expiry = now.Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	return tok
+}
+
+// mapBrokerError translates a non-200 broker response into a sentinel error
+// where one applies, mirroring mapError's mapping for the direct path:
+//
+//   - 400 invalid_grant → ErrInvalidGrant (refresh token expired/revoked)
+//   - 401              → caller-credential error (broker token missing/wrong)
+//   - 502 invalid_client → ErrInvalidClient (broker's own secret is misconfigured)
+//   - any other 5xx    → ErrServerError (upstream timeout / broker fault), matching
+//     mapError, which maps every direct-path 5xx to ErrServerError
+func mapBrokerError(status int, body []byte) error {
+	var er broker.ErrorResponse
+	_ = json.Unmarshal(body, &er)
+
+	switch status {
+	case http.StatusBadRequest:
+		if er.Error == codeInvalidGrant {
+			return fmt.Errorf("%w: %s", ErrInvalidGrant, er.ErrorDescription)
+		}
+		return fmt.Errorf("oauth: broker rejected the request (%s): %s",
+			brokerErrCode(er, status), er.ErrorDescription)
+	case http.StatusUnauthorized:
+		return fmt.Errorf(
+			"oauth: broker rejected the caller credential (status 401); " +
+				"set or correct the broker token")
+	case http.StatusBadGateway:
+		return fmt.Errorf("%w: broker upstream reported invalid_client "+
+			"(the broker's client secret is misconfigured)", ErrInvalidClient)
+	}
+	// Any remaining 5xx (503 upstream-unavailable, 500 broker-internal, 504
+	// gateway-timeout, …) is a server/availability fault, classified like the
+	// direct path so callers and CLI hints behave consistently.
+	if status >= http.StatusInternalServerError {
+		return fmt.Errorf("%w: broker returned status %d (%s)",
+			ErrServerError, status, brokerErrCode(er, status))
+	}
+	return fmt.Errorf("oauth: broker returned unexpected status %d (%s)",
+		status, brokerErrCode(er, status))
+}
+
+// brokerErrCode returns the OAuth2 error code from the body, or a placeholder.
+func brokerErrCode(er broker.ErrorResponse, status int) string {
+	if er.Error != "" {
+		return er.Error
+	}
+	return fmt.Sprintf("http_%d", status)
+}

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -116,13 +116,10 @@ func mapBrokerError(status int, body []byte) error {
 	switch status {
 	case http.StatusBadRequest:
 		if er.Error == codeInvalidGrant {
-			// Omit the description when the broker doesn't supply one, so the
-			// message doesn't end with a dangling ": " while still matching
-			// errors.Is(ErrInvalidGrant).
-			if er.ErrorDescription == "" {
-				return ErrInvalidGrant
-			}
-			return fmt.Errorf("%w: %s", ErrInvalidGrant, er.ErrorDescription)
+			// wrapWithDesc omits the description when the broker doesn't supply
+			// one, so the message doesn't end with a dangling ": " while still
+			// matching errors.Is(ErrInvalidGrant).
+			return wrapWithDesc(ErrInvalidGrant, er.ErrorDescription)
 		}
 		return fmt.Errorf("oauth: broker rejected the request (%s): %s",
 			brokerErrCode(er, status), er.ErrorDescription)

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -56,7 +56,14 @@ func (c *Config) refreshViaBroker(ctx context.Context, refreshToken string) (*oa
 		return nil, fmt.Errorf("%w: broker request failed: %v", ErrServerError, err)
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBrokerResponse))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBrokerResponse))
+	if err != nil {
+		// A failure reading the body (truncated/reset connection) is an
+		// availability problem, not a credential one — classify it like the
+		// transport-level failure above rather than letting a truncated body
+		// fall through to a misleading JSON-decode or error-mapping result.
+		return nil, fmt.Errorf("%w: read broker response failed: %v", ErrServerError, err)
+	}
 
 	if resp.StatusCode == http.StatusOK {
 		var tr broker.TokenResponse

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -121,6 +121,12 @@ func mapBrokerError(status int, body []byte) error {
 			// matching errors.Is(ErrInvalidGrant).
 			return wrapWithDesc(ErrInvalidGrant, er.ErrorDescription)
 		}
+		// Omit the description when absent so the message doesn't end with a
+		// dangling ": " (matching the wrapWithDesc hygiene above).
+		if er.ErrorDescription == "" {
+			return fmt.Errorf("oauth: broker rejected the request (%s)",
+				brokerErrCode(er, status))
+		}
 		return fmt.Errorf("oauth: broker rejected the request (%s): %s",
 			brokerErrCode(er, status), er.ErrorDescription)
 	case http.StatusUnauthorized:

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -73,6 +73,13 @@ func (c *Config) refreshViaBroker(ctx context.Context, refreshToken string) (*oa
 		if tr.AccessToken == "" {
 			return nil, errors.New("oauth: broker returned an empty access token")
 		}
+		// Jira DC rotates the refresh token on every successful refresh and
+		// invalidates the old one, so a missing refresh_token here would leave
+		// the caller with nothing to persist — the next refresh would then fail
+		// with invalid_grant. Treat an empty refresh_token as a broker fault.
+		if tr.RefreshToken == "" {
+			return nil, errors.New("oauth: broker returned an empty refresh token")
+		}
 		return brokerTokenToOAuth2(tr, time.Now()), nil
 	}
 	return nil, mapBrokerError(resp.StatusCode, body)

--- a/pkg/oauth/broker_client.go
+++ b/pkg/oauth/broker_client.go
@@ -104,10 +104,11 @@ func brokerTokenToOAuth2(tr broker.TokenResponse, now time.Time) *oauth2.Token {
 // where one applies, mirroring mapError's mapping for the direct path:
 //
 //   - 400 invalid_grant → ErrInvalidGrant (refresh token expired/revoked)
-//   - 401              → caller-credential error (broker token missing/wrong)
+//   - 401              → ErrBrokerUnauthorized (broker token missing/wrong)
 //   - 502 invalid_client → ErrInvalidClient (broker's own secret is misconfigured)
-//   - any other 5xx    → ErrServerError (upstream timeout / broker fault), matching
-//     mapError, which maps every direct-path 5xx to ErrServerError
+//   - any other 5xx    → ErrServerError (upstream timeout / broker fault, plus a
+//     502 that is not the broker's own invalid_client), matching mapError, which
+//     maps every direct-path 5xx to ErrServerError
 func mapBrokerError(status int, body []byte) error {
 	var er broker.ErrorResponse
 	_ = json.Unmarshal(body, &er)
@@ -115,17 +116,29 @@ func mapBrokerError(status int, body []byte) error {
 	switch status {
 	case http.StatusBadRequest:
 		if er.Error == codeInvalidGrant {
+			// Omit the description when the broker doesn't supply one, so the
+			// message doesn't end with a dangling ": " while still matching
+			// errors.Is(ErrInvalidGrant).
+			if er.ErrorDescription == "" {
+				return ErrInvalidGrant
+			}
 			return fmt.Errorf("%w: %s", ErrInvalidGrant, er.ErrorDescription)
 		}
 		return fmt.Errorf("oauth: broker rejected the request (%s): %s",
 			brokerErrCode(er, status), er.ErrorDescription)
 	case http.StatusUnauthorized:
-		return fmt.Errorf(
-			"oauth: broker rejected the caller credential (status 401); " +
-				"set or correct the broker token")
+		return fmt.Errorf("%w (status 401); set or correct the broker token",
+			ErrBrokerUnauthorized)
 	case http.StatusBadGateway:
-		return fmt.Errorf("%w: broker upstream reported invalid_client "+
-			"(the broker's client secret is misconfigured)", ErrInvalidClient)
+		// Only the broker's own invalid_client (its client_secret is wrong) maps
+		// to ErrInvalidClient. A 502 without that code is almost always an
+		// ingress/proxy gateway error (e.g. an HTML 502 page), so let it fall
+		// through to the generic 5xx → ErrServerError mapping below rather than
+		// blaming the broker's secret.
+		if er.Error == codeInvalidClient {
+			return fmt.Errorf("%w: broker upstream reported invalid_client "+
+				"(the broker's client secret is misconfigured)", ErrInvalidClient)
+		}
 	}
 	// Any remaining 5xx (503 upstream-unavailable, 500 broker-internal, 504
 	// gateway-timeout, …) is a server/availability fault, classified like the

--- a/pkg/oauth/broker_client_test.go
+++ b/pkg/oauth/broker_client_test.go
@@ -127,7 +127,7 @@ func TestRefreshViaBrokerErrorMapping(t *testing.T) {
 			"caller auth",
 			http.StatusUnauthorized,
 			broker.ErrorResponse{Error: "unauthorized"},
-			nil,
+			ErrBrokerUnauthorized,
 			"caller credential",
 		},
 		{
@@ -136,6 +136,23 @@ func TestRefreshViaBrokerErrorMapping(t *testing.T) {
 			broker.ErrorResponse{Error: "invalid_request"},
 			nil,
 			"rejected",
+		},
+		{
+			// invalid_grant with no description must not leave a dangling ": ".
+			"invalid_grant no description",
+			http.StatusBadRequest,
+			broker.ErrorResponse{Error: "invalid_grant"},
+			ErrInvalidGrant,
+			"",
+		},
+		{
+			// A 502 that is NOT the broker's own invalid_client (e.g. an
+			// ingress/proxy gateway error) falls through to ErrServerError.
+			"bad gateway not invalid_client",
+			http.StatusBadGateway,
+			broker.ErrorResponse{Error: "bad_gateway"},
+			ErrServerError,
+			"",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/oauth/broker_client_test.go
+++ b/pkg/oauth/broker_client_test.go
@@ -1,0 +1,157 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/appleboy/go-jira/pkg/broker"
+)
+
+// brokerStub records what the broker received and replies with a canned status
+// and body, standing in for a real broker so the client mapping can be tested.
+type brokerStub struct {
+	gotAuth     string
+	gotClientID string
+	gotRefresh  string
+	status      int
+	body        any
+}
+
+func newBrokerStub(t *testing.T, status int, body any) (*httptest.Server, *brokerStub) {
+	t.Helper()
+	st := &brokerStub{status: status, body: body}
+	mux := http.NewServeMux()
+	mux.HandleFunc(broker.RefreshPath, func(w http.ResponseWriter, r *http.Request) {
+		st.gotAuth = r.Header.Get("Authorization")
+		var req broker.RefreshRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		st.gotClientID = req.ClientID
+		st.gotRefresh = req.RefreshToken
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(st.status)
+		_ = json.NewEncoder(w).Encode(st.body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, st
+}
+
+func TestRefreshViaBrokerSuccess(t *testing.T) {
+	srv, st := newBrokerStub(t, http.StatusOK, broker.TokenResponse{
+		AccessToken:  "access-new",
+		RefreshToken: "refresh-new",
+		ExpiresIn:    7200,
+		TokenType:    "bearer",
+	})
+
+	cfg := &Config{
+		BaseURL:     "https://jira.example.com",
+		ClientID:    "client-abc",
+		BrokerURL:   srv.URL,
+		BrokerToken: "broker-secret",
+	}
+	tok, err := cfg.Refresh(context.Background(), "refresh-old")
+	if err != nil {
+		t.Fatalf("Refresh via broker: %v", err)
+	}
+	if tok.AccessToken != "access-new" || tok.RefreshToken != "refresh-new" {
+		t.Errorf("token = %+v, want rotated pair", tok)
+	}
+	if rem := time.Until(tok.Expiry); rem < 119*time.Minute || rem > 121*time.Minute {
+		t.Errorf("expiry remaining = %v, want ~120m from expires_in", rem)
+	}
+
+	// The client must forward its refresh token + client_id and the bearer token.
+	if st.gotRefresh != "refresh-old" {
+		t.Errorf("broker saw refresh_token %q, want refresh-old", st.gotRefresh)
+	}
+	if st.gotClientID != "client-abc" {
+		t.Errorf("broker saw client_id %q, want client-abc", st.gotClientID)
+	}
+	if st.gotAuth != "Bearer broker-secret" {
+		t.Errorf("broker saw Authorization %q, want Bearer broker-secret", st.gotAuth)
+	}
+}
+
+func TestRefreshViaBrokerNoTokenOmitsAuth(t *testing.T) {
+	srv, st := newBrokerStub(
+		t,
+		http.StatusOK,
+		broker.TokenResponse{AccessToken: "a", RefreshToken: "r"},
+	)
+	cfg := &Config{ClientID: "client-abc", BrokerURL: srv.URL}
+	if _, err := cfg.Refresh(context.Background(), "old"); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if st.gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty when no broker token set", st.gotAuth)
+	}
+}
+
+func TestRefreshViaBrokerErrorMapping(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		body      broker.ErrorResponse
+		wantIs    error  // sentinel the error must match, or nil
+		wantInMsg string // substring expected when no sentinel applies
+	}{
+		{
+			"invalid_grant",
+			http.StatusBadRequest,
+			broker.ErrorResponse{Error: "invalid_grant", ErrorDescription: "revoked"},
+			ErrInvalidGrant,
+			"",
+		},
+		{
+			"invalid_client",
+			http.StatusBadGateway,
+			broker.ErrorResponse{Error: "invalid_client"},
+			ErrInvalidClient,
+			"",
+		},
+		{
+			"upstream",
+			http.StatusServiceUnavailable,
+			broker.ErrorResponse{Error: "server_error"},
+			ErrServerError,
+			"",
+		},
+		{
+			"caller auth",
+			http.StatusUnauthorized,
+			broker.ErrorResponse{Error: "unauthorized"},
+			nil,
+			"caller credential",
+		},
+		{
+			"other bad request",
+			http.StatusBadRequest,
+			broker.ErrorResponse{Error: "invalid_request"},
+			nil,
+			"rejected",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newBrokerStub(t, tc.status, tc.body)
+			cfg := &Config{ClientID: "client-abc", BrokerURL: srv.URL}
+			_, err := cfg.Refresh(context.Background(), "old")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if tc.wantIs != nil && !errors.Is(err, tc.wantIs) {
+				t.Errorf("error %v, want errors.Is %v", err, tc.wantIs)
+			}
+			if tc.wantInMsg != "" && !strings.Contains(err.Error(), tc.wantInMsg) {
+				t.Errorf("error %q, want substring %q", err.Error(), tc.wantInMsg)
+			}
+		})
+	}
+}

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -39,6 +39,25 @@ type Config struct {
 	RedirectURI string   // e.g. "http://127.0.0.1:8765/callback"
 	Scopes      []string // e.g. ["WRITE"]
 
+	// ClientSecret is the confidential-client secret used ONLY on the broker's
+	// direct refresh path. It is left empty on every client; x/oauth2 omits an
+	// empty client_secret, so the public PKCE login/refresh flow is unchanged.
+	// The secret must never be embedded in a published binary — it is injected
+	// from the environment only in the broker process.
+	ClientSecret string
+
+	// BrokerURL, when set, routes Refresh through the token refresh broker
+	// instead of calling Jira DC directly: the client POSTs its refresh_token to
+	// the broker, which adds the client_secret and returns the rotated pair.
+	// Empty preserves the current behaviour (direct refresh against Jira). Only
+	// the refresh path is affected; login is always a direct public PKCE flow.
+	BrokerURL string
+
+	// BrokerToken, when set, is sent as a bearer token on broker requests. It is
+	// an optional, defence-in-depth caller credential; the broker enforces it
+	// only when it is configured there too (see pkg/broker).
+	BrokerToken string
+
 	// TLSCertFile and TLSKeyFile, when both set, make the local callback server
 	// serve HTTPS instead of plain HTTP. Jira DC matches the registered
 	// redirect URI exactly and commonly rejects an http scheme, so an https
@@ -93,13 +112,17 @@ func (c *Config) Validate() error {
 //
 // AuthStyleInParams puts client_id in the request body params, which is what
 // the Jira DC provider expects, and avoids x/oauth2's auto-detect probe
-// request. This is a public PKCE client, so no client secret is sent.
+// request. ClientSecret is empty on every client, and x/oauth2 omits an empty
+// client_secret, so the public PKCE flow sends no secret; only the broker sets
+// ClientSecret, and then it is sent on the direct refresh body as Jira DC's
+// confidential-client refresh requires.
 func (c *Config) oauth2Config() *oauth2.Config {
 	// Trim a trailing slash so a base URL entered as "https://jira.example.com/"
 	// does not yield a double slash ("…com//rest/…") in the endpoint URLs.
 	base := strings.TrimRight(c.BaseURL, "/")
 	return &oauth2.Config{
-		ClientID: c.ClientID,
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:   base + authorizePath,
 			TokenURL:  base + tokenPath,
@@ -113,9 +136,16 @@ func (c *Config) oauth2Config() *oauth2.Config {
 // ctx returns a context carrying the configured HTTP client so x/oauth2 uses
 // it for all token endpoint requests, applying a default timeout otherwise.
 func (c *Config) ctx(parent context.Context) context.Context {
-	hc := c.HTTPClient
-	if hc == nil {
-		hc = &http.Client{Timeout: defaultHTTPTimeout}
+	return context.WithValue(parent, oauth2.HTTPClient, c.httpClient())
+}
+
+// httpClient returns the configured HTTP client, or a default timeout client.
+// The broker caller uses it directly (not via x/oauth2) so refresh requests to
+// the broker honour the same TLS behaviour (internal CA / --insecure) as Jira
+// API calls.
+func (c *Config) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
 	}
-	return context.WithValue(parent, oauth2.HTTPClient, hc)
+	return &http.Client{Timeout: defaultHTTPTimeout}
 }

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -39,11 +39,14 @@ type Config struct {
 	RedirectURI string   // e.g. "http://127.0.0.1:8765/callback"
 	Scopes      []string // e.g. ["WRITE"]
 
-	// ClientSecret is the confidential-client secret used ONLY on the broker's
-	// direct refresh path. It is left empty on every client; x/oauth2 omits an
-	// empty client_secret, so the public PKCE login/refresh flow is unchanged.
-	// The secret must never be embedded in a published binary — it is injected
-	// from the environment only in the broker process.
+	// ClientSecret is the confidential-client secret. It is left empty on every
+	// client; x/oauth2 omits an empty client_secret, so the public PKCE
+	// login/refresh flow sends no secret and is unchanged. The secret must never
+	// be embedded in a published binary — it is injected from the environment
+	// only in the broker process. When set it is part of oauth2Config and is
+	// therefore sent on any token-endpoint call that config drives (Exchange and
+	// refresh alike); in practice only the broker's refresh sends it, because the
+	// broker performs no authorization-code exchange.
 	ClientSecret string
 
 	// BrokerURL, when set, routes Refresh through the token refresh broker
@@ -113,9 +116,11 @@ func (c *Config) Validate() error {
 // AuthStyleInParams puts client_id in the request body params, which is what
 // the Jira DC provider expects, and avoids x/oauth2's auto-detect probe
 // request. ClientSecret is empty on every client, and x/oauth2 omits an empty
-// client_secret, so the public PKCE flow sends no secret; only the broker sets
-// ClientSecret, and then it is sent on the direct refresh body as Jira DC's
-// confidential-client refresh requires.
+// client_secret, so the public PKCE flow sends no secret. When ClientSecret is
+// set (only in the broker process) it is sent on every token-endpoint call this
+// config drives — both Exchange (authorization_code) and refresh — so any caller
+// that must not leak the secret leaves it empty; the broker only ever drives the
+// refresh path.
 func (c *Config) oauth2Config() *oauth2.Config {
 	// Trim a trailing slash so a base URL entered as "https://jira.example.com/"
 	// does not yield a double slash ("…com//rest/…") in the endpoint URLs.

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -26,6 +26,12 @@ var (
 		"oauth: invalid_client (check client_id, or the app may be a confidential " +
 			"client that requires a secret — go-jira only supports public PKCE clients)")
 	ErrServerError = errors.New("oauth: server error")
+	// ErrBrokerUnauthorized means the token refresh broker rejected the caller's
+	// own credential (the JIRA_BROKER_TOKEN bearer was missing or wrong). It is a
+	// 401-class auth failure — distinct from a Jira-side auth failure — so the CLI
+	// classifies it as an auth error (exit 3) on every refresh path by identity,
+	// rather than relying on the wrapping message.
+	ErrBrokerUnauthorized = errors.New("oauth: broker rejected the caller credential")
 )
 
 // mapError translates x/oauth2's *oauth2.RetrieveError into our sentinel

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -23,8 +23,9 @@ const (
 var (
 	ErrInvalidGrant  = errors.New("oauth: invalid_grant (refresh token expired or revoked)")
 	ErrInvalidClient = errors.New(
-		"oauth: invalid_client (check client_id, or the app may be a confidential " +
-			"client that requires a secret — go-jira only supports public PKCE clients)")
+		"oauth: invalid_client (check client_id; if the app is a confidential " +
+			"client that requires a secret on refresh, route refresh through a token " +
+			"refresh broker by setting JIRA_TOKEN_BROKER_URL)")
 	ErrServerError = errors.New("oauth: server error")
 	// ErrBrokerUnauthorized means the token refresh broker rejected the caller's
 	// own credential (the JIRA_BROKER_TOKEN bearer was missing or wrong). It is a

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -8,6 +8,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// RFC 6749 error codes this package recognizes, shared by the direct-path error
+// mapping (mapError) and the broker-path mapping (mapBrokerError).
+const (
+	codeInvalidGrant  = "invalid_grant"
+	codeInvalidClient = "invalid_client"
+)
+
 // Sentinel errors for the well-known OAuth failure modes that callers act on.
 //
 // ErrInvalidGrant is the important one: it means the refresh token has expired
@@ -33,9 +40,9 @@ func mapError(err error) error {
 		return err
 	}
 	switch re.ErrorCode {
-	case "invalid_grant":
+	case codeInvalidGrant:
 		return fmt.Errorf("%w: %s", ErrInvalidGrant, re.ErrorDescription)
-	case "invalid_client":
+	case codeInvalidClient:
 		return fmt.Errorf("%w: %s", ErrInvalidClient, re.ErrorDescription)
 	}
 	if re.Response != nil && re.Response.StatusCode >= http.StatusInternalServerError {

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -35,6 +35,17 @@ var (
 	ErrBrokerUnauthorized = errors.New("oauth: broker rejected the caller credential")
 )
 
+// wrapWithDesc wraps an OAuth sentinel with the provider's error_description, or
+// returns the bare sentinel when no description is supplied so the message never
+// ends with a dangling ": ". Shared by the direct (mapError) and broker
+// (mapBrokerError) paths so both produce identical, clean CLI output.
+func wrapWithDesc(sentinel error, desc string) error {
+	if desc == "" {
+		return sentinel
+	}
+	return fmt.Errorf("%w: %s", sentinel, desc)
+}
+
 // mapError translates x/oauth2's *oauth2.RetrieveError into our sentinel
 // errors where the RFC 6749 'error' code is one we act on, and surfaces 5xx
 // responses as ErrServerError. Other errors pass through unchanged.
@@ -48,9 +59,9 @@ func mapError(err error) error {
 	}
 	switch re.ErrorCode {
 	case codeInvalidGrant:
-		return fmt.Errorf("%w: %s", ErrInvalidGrant, re.ErrorDescription)
+		return wrapWithDesc(ErrInvalidGrant, re.ErrorDescription)
 	case codeInvalidClient:
-		return fmt.Errorf("%w: %s", ErrInvalidClient, re.ErrorDescription)
+		return wrapWithDesc(ErrInvalidClient, re.ErrorDescription)
 	}
 	if re.Response != nil && re.Response.StatusCode >= http.StatusInternalServerError {
 		return fmt.Errorf("%w: %d", ErrServerError, re.Response.StatusCode)

--- a/pkg/oauth/refresh.go
+++ b/pkg/oauth/refresh.go
@@ -8,10 +8,18 @@ import (
 
 // Refresh exchanges a refresh token for a new token pair.
 //
+// When BrokerURL is set the refresh is routed through the token refresh broker
+// (which holds the confidential client_secret); otherwise it calls Jira DC
+// directly as before. Either way the rotated pair is returned with the well-known
+// failures mapped to this package's sentinel errors.
+//
 // ⚠️ On success Jira DC invalidates BOTH the old access token and the old
 // refresh token and returns a new refresh_token in the response. Callers must
 // persist the returned refresh token immediately or the next run will fail.
 func (c *Config) Refresh(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
+	if c.BrokerURL != "" {
+		return c.refreshViaBroker(ctx, refreshToken)
+	}
 	src := c.oauth2Config().TokenSource(c.ctx(ctx), &oauth2.Token{RefreshToken: refreshToken})
 	tok, err := src.Token()
 	if err != nil {

--- a/pkg/oauth/refresh_test.go
+++ b/pkg/oauth/refresh_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"golang.org/x/oauth2"
@@ -51,5 +52,22 @@ func TestRefreshInvalidGrant(t *testing.T) {
 	_, err := testConfig(srv.URL).Refresh(context.Background(), "dead-token")
 	if !errors.Is(err, ErrInvalidGrant) {
 		t.Errorf("error = %v, want errors.Is ErrInvalidGrant", err)
+	}
+}
+
+// When the provider returns invalid_grant with no error_description, the mapped
+// error must still match ErrInvalidGrant and must not end with a dangling ": ".
+func TestRefreshInvalidGrantNoDescription(t *testing.T) {
+	srv := tokenServer(t, func(_ *testing.T, w http.ResponseWriter, _ map[string][]string) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "")
+	})
+	defer srv.Close()
+
+	_, err := testConfig(srv.URL).Refresh(context.Background(), "dead-token")
+	if !errors.Is(err, ErrInvalidGrant) {
+		t.Fatalf("error = %v, want errors.Is ErrInvalidGrant", err)
+	}
+	if strings.HasSuffix(err.Error(), ": ") {
+		t.Errorf("error %q ends with a dangling %q", err.Error(), ": ")
 	}
 }


### PR DESCRIPTION
## Summary

Adds a **token refresh broker** so go-jira can work with a Jira OAuth app configured as a **confidential client** (its token endpoint requires `client_secret` on refresh) without ever shipping the secret in the CLI binary. A new `go-jira broker serve` command holds the `client_secret` server-side and performs the secret-bearing refresh on behalf of public PKCE clients. When `JIRA_TOKEN_BROKER_URL` is set, the CLI routes **only the refresh step** through the broker (covering manual `token refresh`, 401 auto-refresh, and CI `oauth-env`); login and the no-broker direct-refresh path are unchanged.

## Architecture & Flow

### Refresh routing — direct vs broker

```mermaid
flowchart TD
    A["CLI needs to refresh a token<br/>(token refresh · 401 auto-refresh · oauth-env)"] --> B{"JIRA_TOKEN_BROKER_URL set?"}
    B -- "No (default)" --> C["Direct refresh against Jira DC<br/>byte-for-byte unchanged"]
    B -- "Yes" --> D["POST refresh_token + client_id<br/>(+ optional Bearer broker token)<br/>to broker /v1/refresh"]
    D --> E["Broker adds client_secret<br/>and refreshes upstream"]
    C --> F["Rotated access + refresh token pair"]
    E --> F
    F --> G["Persist the rotated refresh_token immediately<br/>(Jira DC invalidates the old one)"]
```

The client **never holds the `client_secret`**: it sends only its `refresh_token` (and optional bearer token). The broker is the only component that knows the secret, and it stores no tokens at rest.

### Broker refresh sequence

```mermaid
sequenceDiagram
    autonumber
    participant CLI as go-jira CLI (PKCE)
    participant Broker as broker serve
    participant Jira as Jira DC token endpoint

    CLI->>Broker: POST /v1/refresh {refresh_token, client_id}<br/>Authorization: Bearer (broker token)
    Note over Broker: caller auth (constant-time)<br/>validate body + client_id<br/>coalesce by sha256(refresh_token)
    alt caller auth fails or bad request
        Broker-->>CLI: 401 unauthorized / 400 invalid_request
    else cache hit or coalesced
        Broker-->>CLI: 200 cached rotated pair
    else upstream refresh
        Broker->>Jira: grant_type=refresh_token + client_secret
        alt success
            Jira-->>Broker: new access + rotated refresh token
            Broker-->>CLI: 200 access_token, refresh_token, expires_in
        else error
            Jira-->>Broker: invalid_grant / invalid_client / 5xx
            Broker-->>CLI: mapped 400 / 502 / 503
        end
    end
    Note over CLI: map back to sentinel errors<br/>invalid_grant - run go-jira login<br/>broker 401 - set or correct the broker token
```

## AI Authorship
- [ ] No AI was used in this PR
- [x] AI was used. Details:
  - **Tool / model**: Claude Opus 4.8 (1M context) via Claude Code
  - **AI-authored files**: all 22 changed files (new `cmd/go-jira/broker.go`, `pkg/broker/*`, `pkg/oauth/broker_client.go`, plus the OAuth/config/docs edits)
  - **Human line-by-line reviewed**: ⚠️ **None yet** — relying on the green test suite (`go test ./...`), `go vet`, `golangci-lint` (0 issues), and the original internal code review. A human line-by-line review is still recommended before merge, especially for the secret-handling paths.

## Change classification
- [x] Core code (broad impact — needs line-by-line review)
  - This touches the OAuth refresh path and introduces server-side handling of the confidential `client_secret` and a bearer-token-authenticated HTTP(S) service. Auth/secret-handling is system-wide and security-sensitive, so the stricter review bar applies even though the feature is opt-in (inert unless `JIRA_TOKEN_BROKER_URL` is set).

## What changed (by mechanism)
- **`broker serve` command** (`cmd/go-jira/broker.go`, `pkg/broker/server.go|types.go`) — an HTTP(S) service that accepts a refresh request, performs the `client_secret`-bearing refresh against Jira's token endpoint, and returns the rotated token pair. The secret is read **only** from the broker's environment (`JIRA_OAUTH_CLIENT_SECRET`, e.g. a Kubernetes Secret sourced from Vault) and never leaves the server.
- **Client-side routing** (`pkg/oauth/broker_client.go`, `pkg/oauth/refresh.go`, `pkg/oauth/config.go`) — when `JIRA_TOKEN_BROKER_URL` is set, refresh is sent to the broker instead of calling Jira directly. With the env var unset, behaviour is byte-for-byte identical to today (direct refresh). The broker URL should use `https` (or have TLS terminated at an ingress in front of the broker): a plain-`http` broker URL would send the `refresh_token` and bearer token over the wire in cleartext, so the client logs a warning when it is plain `http`.
- **Concurrency** — the broker coalesces concurrent refreshes of the same token into a single upstream call via a short-lived in-memory cache; it stores no tokens at rest.
- **Error fidelity** (`pkg/oauth/errors.go`) — broker responses are mapped back to the existing OAuth error sentinels (`invalid_grant`, etc.) so the CLI's recovery hints (`token refresh` → `login`) stay intact.
- **Observability** (`cmd/go-jira/config.go`, `config_cmd.go`) — `config show` now reports `broker_url` and a **redacted** `broker_token`.
- **Docs** (`docs/oauth-usage.md`, `README*.md`) — deployment (k8s + Vault), the env contract, and the security model.

## Plan reference
Cherry-picked from the internal feature branch onto `upstream/main` as a clean port: upstream's public defaults (`jira.example.com`, callback port `8765`) and module path (`github.com/appleboy/go-jira`) were preserved; only the broker feature was added.

## Verification
- [x] Unit tests — `pkg/broker/server_test.go` (broker refresh, coalescing, auth, error mapping), `pkg/oauth/broker_client_test.go` (client routing), `cmd/go-jira/broker_config_test.go`, `broker_serve_test.go`
- [x] Integration / e2e tests — `cmd/go-jira/broker_e2e_test.go` exercises the real CLI → broker → upstream refresh flow end to end
- [x] At least 3 e2e tests (happy path + error cases: invalid_grant, broker auth, upstream failure)
- [ ] Stress / soak test: N/A (coalescing is covered by a concurrency unit test rather than a soak test)
- **Commands run**: `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test ./...` — all green.
- **Manual verification**: not performed against a live confidential client in this PR — see review note above.

## Post-review fixes
An automated code-review pass (Claude Code, Opus 4.8) reviewed the diff; the following hardening was applied in commit `aa78ee3`, with `go build`, `go vet`, `golangci-lint` (0 issues) and `go test -race ./...` staying green:
- **`config show` source label** — when both `JIRA_TOKEN_BROKER_URL`/`JIRA_BROKER_TOKEN` and their flags were set, the table printed the env value but labelled the source `flag`; the broker rows now resolve env-first (matching `resolveWithEnv`'s precedence), backed by a regression test.
- **Cleartext-http warning** — the client now logs a warning when `JIRA_TOKEN_BROKER_URL` is plain `http` (the `refresh_token` and bearer token would otherwise go out unencrypted).
- **Nil-token guard** — `handleRefresh` now returns a `server_error` instead of panicking the handler (and every coalesced waiter on that key) if a `RefreshFunc` ever returns `(nil, nil)`.
- **Constant-time auth micro-opt** — the configured caller token's SHA-256 is precomputed once at construction instead of being re-hashed on every request.
- **Error-message hygiene** — dropped a dangling `": "` on the broker-path 400 error when the broker supplies no description.

A follow-up performance pass (commit `ab9ad14`) fixed the one hot-path issue that scales with load:
- **Amortized result-cache eviction** — `evictExpiredLocked` previously scanned the whole `results` map under the global lock on *every* `/v1/refresh`, so a burst of distinct refresh tokens made every later request (even cache hits for unrelated keys) pay an O(n) sweep while holding the lock. Eviction now runs at most once per TTL window, and a per-key freshness check keeps correctness independent of the sweep cadence, so the hot path is O(1). Covered by a new regression test.

Still reported but intentionally not changed (out of scope / by design): the `429`/`403` exit-code classification gap noted above, the optional-by-default caller auth + plain-HTTP serving (network-layer is the primary control), and the three-hop sentinel↔HTTP-status mapping. From the performance pass: the in-memory cache has no hard entry cap (it stays bounded by the TTL window — the eviction fix removes the CPU/lock cost of a token flood but not its memory growth), plus assorted per-request micro-allocations (per-refresh `oauth2Config`/`http.Client`, hex cache keys) that are dwarfed by the upstream network round-trip.

## Verifiability check
- [x] Inputs and outputs are documented — the broker HTTP contract and env vars are documented in `docs/oauth-usage.md`; the observable surface is the refreshed token pair and the mapped error sentinels
- [x] Reviewer can judge correctness from the e2e/unit tests and the documented contract without reading every line
- [x] Failures surface through the existing structured OAuth error envelope and CLI exit codes

## Security check (touches external interfaces + secret handling)
- [x] No secrets in code — the `client_secret` is read only from the broker's environment; nothing is embedded in the binary or committed
- [x] All external inputs validated — broker validates the inbound request and enforces the shared `JIRA_BROKER_TOKEN` bearer when configured
- [x] Permission checks tested — broker auth (token required / rejected) is covered in `pkg/broker/server_test.go`
- [ ] Rate limits — not added at the broker layer (refresh coalescing limits duplicate upstream calls); flag if reviewers want explicit rate limiting. Note: the broker client does not pass through the CLI's diagnostic transport, so a `429`/`403` returned by a proxy in front of the broker is currently surfaced as a generic error (exit 1) rather than `rate_limit`/`auth`.
- [x] Errors don't leak internals — responses are mapped to generic OAuth sentinels; `config show` redacts `broker_token`; the secret is never returned

## Risk & rollback
- **Risk**: the feature is opt-in and inert unless `JIRA_TOKEN_BROKER_URL` is set, so the blast radius for existing users is minimal. The main risk surface is the new server-side secret handling in the broker — the reason a line-by-line review is recommended.
- **Rollback**: revert this single commit; no schema/state migrations, and clients with the env var unset are unaffected.

## Reviewer guide
- **Read carefully**: `pkg/broker/server.go` (secret handling, refresh, coalescing, TLS), `pkg/oauth/broker_client.go` (client routing), `cmd/go-jira/broker.go` (env/flag wiring, `JIRA_OAUTH_CLIENT_SECRET` confinement).
- **Spot-check OK**: `README*.md` / `docs/oauth-usage.md` (docs), `config.go`/`config_cmd.go` (redacted reporting), the `*_test.go` files (read assertions to calibrate, but they back the above).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


