### PR TITLE
feat(cli): add delete subcommand to remove Jira issues

### DIFF
--- a/cmd/go-jira/datacmd_test.go
+++ b/cmd/go-jira/datacmd_test.go
@@ -396,6 +396,77 @@ func TestBoardsCmd(t *testing.T) {
 	}
 }
 
+func TestDeleteCmdMissingConfirm(t *testing.T) {
+	_, err := runDataCmd(t, newDeleteCmd(), "https://example.invalid", "--key", "GAIA-1")
+	if err == nil || !strings.Contains(err.Error(), "--confirm") {
+		t.Fatalf("expected --confirm error, got %v", err)
+	}
+}
+
+func TestDeleteCmd(t *testing.T) {
+	var gotMethod, gotPath string
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer server.Close()
+
+	out, err := runDataCmd(t, newDeleteCmd(), server.URL, "--key", "GAIA-123", "--confirm")
+	if err != nil {
+		t.Fatalf("delete returned error: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("expected DELETE request, got %s", gotMethod)
+	}
+	if gotPath != "/rest/api/2/issue/GAIA-123" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(out, "deleted") || !strings.Contains(out, "GAIA-123") {
+		t.Errorf("delete output unexpected: %s", out)
+	}
+}
+
+func TestDeleteCmdSubtasks(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer server.Close()
+
+	_, err := runDataCmd(t, newDeleteCmd(), server.URL,
+		"--key", "GAIA-123", "--confirm", "--delete-subtasks")
+	if err != nil {
+		t.Fatalf("delete --delete-subtasks returned error: %v", err)
+	}
+	if gotQuery != "deleteSubtasks=true" {
+		t.Errorf("expected deleteSubtasks=true query param, got %q", gotQuery)
+	}
+}
+
+func TestDeleteCmdNotFound(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist"]}`))
+		}),
+	)
+	defer server.Close()
+
+	_, err := runDataCmd(t, newDeleteCmd(), server.URL, "--key", "GAIA-999", "--confirm")
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+	if !strings.Contains(err.Error(), "GAIA-999") {
+		t.Errorf("error should mention the issue key, got: %v", err)
+	}
+}
+
 func TestLinkCmd(t *testing.T) {
 	var gotBody jira.IssueLink
 	server := httptest.NewServer(

--- a/cmd/go-jira/datacmd_test.go
+++ b/cmd/go-jira/datacmd_test.go
@@ -404,11 +404,12 @@ func TestDeleteCmdMissingConfirm(t *testing.T) {
 }
 
 func TestDeleteCmd(t *testing.T) {
-	var gotMethod, gotPath string
+	var gotMethod, gotPath, gotQuery string
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotMethod = r.Method
 			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
 			w.WriteHeader(http.StatusNoContent)
 		}),
 	)
@@ -423,6 +424,11 @@ func TestDeleteCmd(t *testing.T) {
 	}
 	if gotPath != "/rest/api/2/issue/GAIA-123" {
 		t.Errorf("unexpected path: %s", gotPath)
+	}
+	// Without --delete-subtasks the cascade param must be absent; otherwise a
+	// regression that always cascades would slip past TestDeleteCmdSubtasks.
+	if gotQuery != "" {
+		t.Errorf("expected no query string by default, got %q", gotQuery)
 	}
 	if !strings.Contains(out, "deleted") || !strings.Contains(out, "GAIA-123") {
 		t.Errorf("delete output unexpected: %s", out)
@@ -464,6 +470,11 @@ func TestDeleteCmdNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "GAIA-999") {
 		t.Errorf("error should mention the issue key, got: %v", err)
+	}
+	// Assert the 404 actually surfaced, not merely some non-2xx — otherwise this
+	// test would still pass if the not-found path silently degraded.
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should surface the 404 status, got: %v", err)
 	}
 }
 

--- a/cmd/go-jira/delete.go
+++ b/cmd/go-jira/delete.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -39,7 +40,7 @@ func newDeleteCmd() *cobra.Command {
 func runDelete(cmd *cobra.Command) error {
 	confirm, _ := cmd.Flags().GetBool(flagConfirm)
 	if !confirm {
-		return fmt.Errorf("use --confirm to confirm deletion")
+		return errors.New("use --confirm to confirm deletion")
 	}
 
 	config, err := loadDataConfig(cmd)
@@ -57,6 +58,9 @@ func runDelete(cmd *cobra.Command) error {
 		return err
 	}
 
+	// Build the DELETE request by hand rather than via Issue.DeleteWithContext:
+	// that SDK helper hardcodes deleteSubtasks=true, so it cannot honor the
+	// default (--delete-subtasks=false). Send the flag as a query param instead.
 	u := &url.URL{Path: "rest/api/2/issue/" + key}
 	if deleteSubtasks {
 		u.RawQuery = "deleteSubtasks=true"

--- a/cmd/go-jira/delete.go
+++ b/cmd/go-jira/delete.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Short:   "Delete a Jira issue",
+		GroupID: groupIssues,
+		Example: `  # Delete an issue (confirmation required)
+  go-jira delete --key GAIA-123 --confirm
+
+  # Delete an issue and its subtasks
+  go-jira delete --key GAIA-123 --confirm --delete-subtasks`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDelete(cmd)
+		},
+	}
+	addCommonFlags(cmd)
+	addOAuthFlags(cmd)
+	addAuthFlags(cmd)
+	addOutputFlag(cmd)
+	cmd.Flags().String(flagKey, "", "Issue key to delete, e.g. GAIA-123 (required)")
+	_ = cmd.MarkFlagRequired(flagKey)
+	cmd.Flags().Bool(flagConfirm, false, "Confirm the deletion (required)")
+	cmd.Flags().Bool(flagDeleteSubtasks, false, "Also delete all subtasks of the issue")
+	return cmd
+}
+
+func runDelete(cmd *cobra.Command) error {
+	confirm, _ := cmd.Flags().GetBool(flagConfirm)
+	if !confirm {
+		return fmt.Errorf("use --confirm to confirm deletion")
+	}
+
+	config, err := loadDataConfig(cmd)
+	if err != nil {
+		return err
+	}
+	key, _ := cmd.Flags().GetString(flagKey)
+	deleteSubtasks, _ := cmd.Flags().GetBool(flagDeleteSubtasks)
+
+	ctx, cancel := cmdContextWithTimeout(cmd, time.Minute)
+	defer cancel()
+
+	jiraClient, err := resolveJiraClient(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	u := &url.URL{Path: "rest/api/2/issue/" + key}
+	if deleteSubtasks {
+		u.RawQuery = "deleteSubtasks=true"
+	}
+	apiPath := u.String()
+
+	req, err := jiraClient.NewRequestWithContext(ctx, http.MethodDelete, apiPath, nil)
+	if err != nil {
+		return fmt.Errorf("error building delete request for %s: %w", key, err)
+	}
+	resp, err := jiraClient.Do(req, nil)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting issue %s: %w", key, err)
+	}
+
+	result := map[string]string{statusKey: "deleted", flagKey: key}
+	return emitResult(config, result, func() {
+		fmt.Fprintf(os.Stdout, "deleted %s\n", key)
+	})
+}

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -74,6 +74,10 @@ const (
 	flagCallbackHTTPS = "callback-https"
 	flagScope         = "scope"
 	flagTimeout       = "timeout"
+
+	// Confirmation and cascade flags for destructive commands: --confirm guards
+	// `token print` and `delete`; --delete-subtasks cascades an issue delete to
+	// its subtasks.
 	flagConfirm        = "confirm"
 	flagDeleteSubtasks = "delete-subtasks"
 

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -74,7 +74,8 @@ const (
 	flagCallbackHTTPS = "callback-https"
 	flagScope         = "scope"
 	flagTimeout       = "timeout"
-	flagConfirm       = "confirm"
+	flagConfirm        = "confirm"
+	flagDeleteSubtasks = "delete-subtasks"
 
 	// Token refresh broker flags. --broker-url / --broker-token are client-side
 	// (route refresh through the broker); --listen / --tls-cert / --tls-key are
@@ -286,6 +287,7 @@ Composability:
 		newSearchCmd(),
 		newCreateCmd(),
 		newUpdateCmd(),
+		newDeleteCmd(),
 		newGetCmd(),
 		newSprintsCmd(),
 		newEpicsCmd(),


### PR DESCRIPTION
## Summary

Adds a `go-jira delete` subcommand so users can delete Jira issues directly from the CLI without falling back to raw `curl` commands. Requires `--confirm` to prevent accidental deletion, and supports `--delete-subtasks` to cascade the deletion to subtasks.

## Architecture / flow

```mermaid
sequenceDiagram
    participant User
    participant CLI as go-jira delete
    participant Client as resolveJiraClient()
    participant API as Jira REST API

    User->>CLI: --key GAIA-123 --confirm
    CLI->>CLI: abort if --confirm not set
    CLI->>Client: loadDataConfig() + resolveJiraClient()
    Client-->>CLI: *jira.Client
    CLI->>API: DELETE /rest/api/2/issue/GAIA-123
    API-->>CLI: 204 No Content
    CLI-->>User: deleted GAIA-123
```

## AI Authorship

- [x] AI was used. Details:
  - **Tool / model**: Claude Sonnet 4.6 via Claude Code CLI
  - **AI-authored files**: `cmd/go-jira/delete.go`, `cmd/go-jira/datacmd_test.go` (new tests), `cmd/go-jira/main.go` (flag constant + registration)
  - **Human line-by-line reviewed**: all files reviewed in session; simplify pass applied

## Change classification

- [x] Leaf node (local impact) — new independent subcommand; no existing code depends on it; failure is isolated to the `delete` path

## Plan reference

`plan.md` exists at repo root. Goal: replace the raw `curl` workaround in the `jira-create-issue` skill with a first-class CLI command.

Scope respected: only `cmd/go-jira/delete.go` (new), `cmd/go-jira/main.go` (2 lines), `cmd/go-jira/datacmd_test.go` (tests) were touched.

## Verification

- [x] Unit tests: 4 added in `datacmd_test.go`
  1. Happy path: `DELETE /rest/api/2/issue/GAIA-123` → 204, output contains "deleted GAIA-123"
  2. `--delete-subtasks`: query param `deleteSubtasks=true` sent correctly
  3. Missing `--confirm`: exits with error mentioning `--confirm`, no request made
  4. 404 not found: error message includes the issue key
- [x] `go test ./cmd/go-jira/...` passes
- [x] `go vet ./...` clean
- [ ] Stress / soak test: N/A (single DELETE request, no concurrency)
- Manual verification: `go-jira delete --key <KEY> --confirm` against a real Jira instance

## Risk & rollback

- **Risk**: Minimal — new subcommand with no shared state. A bug affects only callers of `delete`.
- **Rollback**: Delete `cmd/go-jira/delete.go`, revert the two-line addition in `main.go`.

## Reviewer guide

- **Read carefully**: `cmd/go-jira/delete.go` — especially the `--confirm` guard order and the `resp.Body.Close()` placement relative to the `err` check (mirrors `update.go` exactly)
- **Spot-check OK**: `main.go` (flag constant + one `AddCommand` line), `datacmd_test.go` (standard httptest pattern used throughout the file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)