### PR TITLE
fix(cli)!: require Jira-scoped base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Stop reading the generic `BASE_URL` environment variable.** This is a
+  breaking change for users who rely on `BASE_URL` for the Jira instance URL.
+  Use `JIRA_BASE_URL` for local and `.env` configuration;
+  `INPUT_BASE_URL` remains supported for GitHub/Gitea Actions, and the explicit
+  `--base-url` flag remains the highest-priority setting. This prevents
+  unrelated application configuration from changing the Jira target.
+
 ## v0.14.1 - 2026-07-17
 
 ### Internal

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ go-jira supports four authentication modes:
 | JIRA_OAUTH_CALLBACK_HTTPS       | `true` to serve the HTTPS callback with an auto-generated in-memory cert (no cert files; browser shows a one-time warning) |
 | JIRA_MASTER_PASSWORD            | Master password for the encrypted file token store (when no keyring)                                                       |
 
+`JIRA_BASE_URL` is the canonical variable for local use and `.env` files.
+`INPUT_BASE_URL` remains supported for GitHub/Gitea Actions. `BASE_URL` is a
+legacy, lowest-priority fallback. If both `JIRA_BASE_URL` and `BASE_URL` are set,
+`JIRA_BASE_URL` wins.
+
 ### Usage
 
 The Action behavior runs under the `run` subcommand. All action flags and the

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ go-jira supports four authentication modes:
 | JIRA_MASTER_PASSWORD            | Master password for the encrypted file token store (when no keyring)                                                       |
 
 `JIRA_BASE_URL` is the canonical variable for local use and `.env` files.
-`INPUT_BASE_URL` remains supported for GitHub/Gitea Actions. `BASE_URL` is a
-legacy, lowest-priority fallback. If both `JIRA_BASE_URL` and `BASE_URL` are set,
-`JIRA_BASE_URL` wins.
+`INPUT_BASE_URL` remains supported for GitHub/Gitea Actions. The generic
+`BASE_URL` variable is not read, preventing unrelated application settings from
+changing the Jira target.
 
 ### Usage
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -146,8 +146,8 @@ go-jira 支持四种认证模式：
 | JIRA_MASTER_PASSWORD            | 加密文件 token 存储的主密码（无 keyring 时）       |
 
 `JIRA_BASE_URL` 是本地环境和 `.env` 文件使用的正式名称。`INPUT_BASE_URL` 保留供
-GitHub/Gitea Actions 使用；`BASE_URL` 仅作为最低优先级的旧版兼容回退值。
-同时设置 `JIRA_BASE_URL` 和 `BASE_URL` 时，将采用 `JIRA_BASE_URL`。
+GitHub/Gitea Actions 使用。程序不会读取通用的 `BASE_URL`，避免其他应用程序的
+设置意外改变 Jira 目标。
 
 ### 使用示例
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -145,6 +145,10 @@ go-jira 支持四种认证模式：
 | JIRA_OAUTH_REFRESH_TOKEN_OUTPUT | 写入轮换后 refresh token 的文件路径                |
 | JIRA_MASTER_PASSWORD            | 加密文件 token 存储的主密码（无 keyring 时）       |
 
+`JIRA_BASE_URL` 是本地环境和 `.env` 文件使用的正式名称。`INPUT_BASE_URL` 保留供
+GitHub/Gitea Actions 使用；`BASE_URL` 仅作为最低优先级的旧版兼容回退值。
+同时设置 `JIRA_BASE_URL` 和 `BASE_URL` 时，将采用 `JIRA_BASE_URL`。
+
 ### 使用示例
 
 > Action 行为在 `run` 子命令下执行。所有动作标志与 GitHub Actions 的 `INPUT_*`

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -146,8 +146,8 @@ go-jira 支援四種認證模式：
 | JIRA_MASTER_PASSWORD            | 加密檔 token 儲存的主密碼（無 keyring 時）         |
 
 `JIRA_BASE_URL` 是本機與 `.env` 檔案使用的正式名稱。`INPUT_BASE_URL` 保留供
-GitHub/Gitea Actions 使用；`BASE_URL` 僅為最低優先序的舊版相容後備值。
-若 `JIRA_BASE_URL` 與 `BASE_URL` 同時存在，將採用 `JIRA_BASE_URL`。
+GitHub/Gitea Actions 使用。程式不會讀取通用的 `BASE_URL`，避免其他應用程式的
+設定意外改變 Jira 目標。
 
 ### 使用範例
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -145,6 +145,10 @@ go-jira 支援四種認證模式：
 | JIRA_OAUTH_REFRESH_TOKEN_OUTPUT | 寫入輪換後 refresh token 的檔案路徑                |
 | JIRA_MASTER_PASSWORD            | 加密檔 token 儲存的主密碼（無 keyring 時）         |
 
+`JIRA_BASE_URL` 是本機與 `.env` 檔案使用的正式名稱。`INPUT_BASE_URL` 保留供
+GitHub/Gitea Actions 使用；`BASE_URL` 僅為最低優先序的舊版相容後備值。
+若 `JIRA_BASE_URL` 與 `BASE_URL` 同時存在，將採用 `JIRA_BASE_URL`。
+
 ### 使用範例
 
 > Action 行為在 `run` 子命令下執行。所有動作旗標與 GitHub Actions 的 `INPUT_*`

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -66,14 +66,14 @@ type Config struct {
 // resolveBaseURL resolves the Jira URL separately from the other action
 // settings. JIRA_BASE_URL is the canonical local/.env name, while
 // INPUT_BASE_URL remains ahead of it for GitHub/Gitea Actions compatibility.
-// The generic BASE_URL is accepted only as the lowest-priority legacy fallback
-// so an unrelated value cannot override an explicitly Jira-scoped setting.
+// The generic BASE_URL is intentionally not read so unrelated application
+// configuration cannot affect the Jira target.
 func resolveBaseURL(cmd *cobra.Command) string {
 	if flagChanged(cmd, flagBaseURL) {
 		v, _ := cmd.Flags().GetString(flagBaseURL)
 		return v
 	}
-	for _, key := range []string{envInputBaseURL, envBaseURL, envLegacyBaseURL} {
+	for _, key := range []string{envInputBaseURL, envBaseURL} {
 		if v := os.Getenv(key); v != "" {
 			return v
 		}

--- a/cmd/go-jira/config.go
+++ b/cmd/go-jira/config.go
@@ -63,13 +63,28 @@ type Config struct {
 	brokerToken string
 }
 
-// loadConfig resolves configuration from CLI flags (when explicitly set)
-// falling back to environment variables via util.GetGlobalValue.
-//
-// The INPUT_<KEY> → <KEY> lookup order inside util.GetGlobalValue is preserved
-// verbatim, so GitHub Actions (which sets INPUT_*) and local .env usage both
-// keep working. Passing cmd == nil sends every action lookup straight to the
-// environment, keeping tests and non-cobra callers working unchanged.
+// resolveBaseURL resolves the Jira URL separately from the other action
+// settings. JIRA_BASE_URL is the canonical local/.env name, while
+// INPUT_BASE_URL remains ahead of it for GitHub/Gitea Actions compatibility.
+// The generic BASE_URL is accepted only as the lowest-priority legacy fallback
+// so an unrelated value cannot override an explicitly Jira-scoped setting.
+func resolveBaseURL(cmd *cobra.Command) string {
+	if flagChanged(cmd, flagBaseURL) {
+		v, _ := cmd.Flags().GetString(flagBaseURL)
+		return v
+	}
+	for _, key := range []string{envInputBaseURL, envBaseURL, envLegacyBaseURL} {
+		if v := os.Getenv(key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// loadConfig resolves configuration from CLI flags (when explicitly set),
+// falling back to environment variables. Most action settings preserve the
+// INPUT_<KEY> → <KEY> order from util.GetGlobalValue; the base URL uses the
+// Jira-specific order documented by resolveBaseURL.
 func loadConfig(cmd *cobra.Command) Config {
 	getString := func(flagName, envKey string) string {
 		if cmd != nil && cmd.Flags().Lookup(flagName) != nil && cmd.Flags().Changed(flagName) {
@@ -87,7 +102,7 @@ func loadConfig(cmd *cobra.Command) Config {
 	}
 
 	cfg := Config{
-		baseURL:      getString(flagBaseURL, "base_url"),
+		baseURL:      resolveBaseURL(cmd),
 		insecure:     getBool(flagInsecure, "insecure"),
 		username:     getString(flagUsername, "username"),
 		password:     getString(flagPassword, "password"),
@@ -118,12 +133,8 @@ func loadConfig(cmd *cobra.Command) Config {
 		cfg.sprintField = defaultSprintField
 	}
 
-	// Accept the JIRA_-prefixed env vars as aliases (lowest precedence: flag >
-	// INPUT_<KEY>/<KEY> > JIRA_<KEY>), so the JIRA_* examples in the docs and
-	// the auth-resolver error message work as written.
-	if cfg.baseURL == "" {
-		cfg.baseURL = os.Getenv(envBaseURL)
-	}
+	// Accept JIRA_-prefixed aliases for the remaining core auth fields (lowest
+	// precedence: flag > INPUT_<KEY>/<KEY> > JIRA_<KEY>).
 	if cfg.username == "" {
 		cfg.username = os.Getenv(envUsername)
 	}

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -12,9 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// sourceEnv is the SOURCE column value reported when a config value was
-// resolved from an environment variable.
-const sourceEnv = "env"
+// SOURCE column values reported by `config show`.
+const (
+	sourceEnv     = "env"
+	sourceFlag    = "flag"
+	sourceDefault = "default/unset"
+)
 
 // newConfigCmd builds the `config` command group.
 func newConfigCmd() *cobra.Command {
@@ -71,7 +74,8 @@ func runConfigShow(cmd *cobra.Command) error {
 			oauthValueSource(cmd, flagName, envKey, value, embedded))
 	}
 
-	row("base_url", config.baseURL, flagBaseURL, "base_url", envBaseURL)
+	fmt.Fprintf(w, "base_url\t%s\t%s\n",
+		redactIfSecret("base_url", config.baseURL), baseURLSource(cmd))
 	row("insecure", fmt.Sprintf("%t", config.insecure), flagInsecure, "insecure", envInsecure)
 	row("token", config.token, flagToken, "token", envToken)
 	row("username", config.username, flagUsername, "username", envUsername)
@@ -126,12 +130,25 @@ func oauthValueSource(cmd *cobra.Command, flagName, envKey, value, embedded stri
 		return sourceEnv
 	}
 	if flagChanged(cmd, flagName) {
-		return "flag"
+		return sourceFlag
 	}
 	if embedded != "" && value == embedded {
 		return "embedded-default"
 	}
-	return "default/unset"
+	return sourceDefault
+}
+
+// baseURLSource mirrors resolveBaseURL without treating the generic BASE_URL
+// as a valid source. Keeping this separate from configSource avoids the latter's
+// INPUT_<KEY>/<KEY> convention, which remains correct for the other fields.
+func baseURLSource(cmd *cobra.Command) string {
+	if flagChanged(cmd, flagBaseURL) {
+		return sourceFlag
+	}
+	if os.Getenv(envInputBaseURL) != "" || os.Getenv(envBaseURL) != "" {
+		return sourceEnv
+	}
+	return sourceDefault
 }
 
 // configSource reports where a value came from: flag, env, or default/unset.
@@ -142,7 +159,7 @@ func oauthValueSource(cmd *cobra.Command, flagName, envKey, value, embedded stri
 func configSource(cmd *cobra.Command, flagName, envKey, aliasEnv string) string {
 	if cmd != nil && flagName != "" && cmd.Flags().Lookup(flagName) != nil &&
 		cmd.Flags().Changed(flagName) {
-		return "flag"
+		return sourceFlag
 	}
 	if envKey != "" && util.GetGlobalValue(envKey) != "" {
 		return sourceEnv
@@ -150,7 +167,7 @@ func configSource(cmd *cobra.Command, flagName, envKey, aliasEnv string) string 
 	if aliasEnv != "" && os.Getenv(aliasEnv) != "" {
 		return sourceEnv
 	}
-	return "default/unset"
+	return sourceDefault
 }
 
 // detectAuthMode reports which auth mode run would select, mirroring

--- a/cmd/go-jira/config_cmd.go
+++ b/cmd/go-jira/config_cmd.go
@@ -135,9 +135,10 @@ func oauthValueSource(cmd *cobra.Command, flagName, envKey, value, embedded stri
 }
 
 // configSource reports where a value came from: flag, env, or default/unset.
-// aliasEnv, when non-empty, is a JIRA_-prefixed alias (e.g. JIRA_BASE_URL)
-// checked alongside the INPUT_<KEY>/<KEY> convention so the reported source
-// matches loadConfig's resolution.
+// aliasEnv, when non-empty, is an additional JIRA_-prefixed environment name
+// checked alongside the INPUT_<KEY>/<KEY> convention. This function reports
+// only the source category, so precedence between environment names does not
+// affect its result.
 func configSource(cmd *cobra.Command, flagName, envKey, aliasEnv string) string {
 	if cmd != nil && flagName != "" && cmd.Flags().Lookup(flagName) != nil &&
 		cmd.Flags().Changed(flagName) {

--- a/cmd/go-jira/config_test.go
+++ b/cmd/go-jira/config_test.go
@@ -431,13 +431,16 @@ func TestLoadConfig(t *testing.T) {
 }
 
 // TestLoadConfig_InputPrefixStillWorks is a regression guard for the
-// GitHub Actions code path: when only INPUT_* env vars are present (and no
-// flags are passed), loadConfig must still pick them up via
-// util.GetGlobalValue. This is the exact path CI/CD relies on.
+// GitHub Actions code path: when INPUT_* env vars are present (and no flags
+// are passed), loadConfig must still pick them up. INPUT_BASE_URL also remains
+// ahead of the local and legacy base-URL names; this is the path CI/CD relies
+// on.
 func TestLoadConfig_InputPrefixStillWorks(t *testing.T) {
 	clearInputEnv(t)
 
-	os.Setenv("INPUT_BASE_URL", "https://from-input.example.com")
+	os.Setenv(envInputBaseURL, "https://from-input.example.com")
+	os.Setenv(envBaseURL, "https://from-jira.example.com")
+	os.Setenv(envLegacyBaseURL, "https://from-legacy.example.com")
 	os.Setenv("INPUT_TOKEN", "input-token")
 	os.Setenv("INPUT_REF", "ABC-1")
 	os.Setenv("INPUT_MARKDOWN", "true")
@@ -458,13 +461,12 @@ func TestLoadConfig_InputPrefixStillWorks(t *testing.T) {
 	}
 }
 
-// TestLoadConfig_BareEnvStillWorks confirms the fallback path
-// (INPUT_* unset, only bare KEY env vars set) keeps working — this is how
-// local .env files drive the tool.
+// TestLoadConfig_BareEnvStillWorks confirms the legacy fallback path
+// (INPUT_* and JIRA_BASE_URL unset, only bare KEY env vars set) keeps working.
 func TestLoadConfig_BareEnvStillWorks(t *testing.T) {
 	clearInputEnv(t)
 
-	os.Setenv("BASE_URL", "https://from-bare.example.com")
+	os.Setenv(envLegacyBaseURL, "https://from-bare.example.com")
 	os.Setenv("TOKEN", "bare-token")
 	os.Setenv("REF", "ABC-2")
 
@@ -512,21 +514,31 @@ func TestLoadConfig_JiraAliasesWork(t *testing.T) {
 	}
 }
 
-// TestLoadConfig_BareEnvBeatsJiraAlias verifies precedence: the existing
-// INPUT_<KEY>/<KEY> convention wins over the JIRA_ alias when both are set.
-func TestLoadConfig_BareEnvBeatsJiraAlias(t *testing.T) {
+// TestLoadConfig_JiraBaseURLBeatsLegacyBaseURL guards against collisions with
+// a generic BASE_URL set by another tool or loaded into the process first.
+func TestLoadConfig_JiraBaseURLBeatsLegacyBaseURL(t *testing.T) {
 	clearInputEnv(t)
 
-	os.Setenv("BASE_URL", "https://from-bare.example.com")
-	os.Setenv("JIRA_BASE_URL", "https://from-jira.example.com")
-	os.Setenv("TOKEN", "bare-token")
-	os.Setenv("JIRA_TOKEN", "jira-token")
+	os.Setenv(envLegacyBaseURL, "https://from-legacy.example.com")
+	os.Setenv(envBaseURL, "https://from-jira.example.com")
 
 	got := loadConfig(nil)
 
-	if got.baseURL != "https://from-bare.example.com" {
-		t.Errorf("baseURL = %q, want BASE_URL to win over JIRA_BASE_URL", got.baseURL)
+	if got.baseURL != "https://from-jira.example.com" {
+		t.Errorf("baseURL = %q, want JIRA_BASE_URL to win over legacy BASE_URL", got.baseURL)
 	}
+}
+
+// TestLoadConfig_BareTokenBeatsJiraAlias preserves the existing credential
+// precedence; only the base URL gives the JIRA_-prefixed name higher priority.
+func TestLoadConfig_BareTokenBeatsJiraAlias(t *testing.T) {
+	clearInputEnv(t)
+
+	os.Setenv("TOKEN", "bare-token")
+	os.Setenv(envToken, "jira-token")
+
+	got := loadConfig(nil)
+
 	if got.token != "bare-token" {
 		t.Errorf("token = %q, want TOKEN to win over JIRA_TOKEN", got.token)
 	}
@@ -539,6 +551,8 @@ func TestLoadConfig_FlagOverridesEnv(t *testing.T) {
 	clearInputEnv(t)
 
 	os.Setenv("INPUT_BASE_URL", "https://from-env.example.com")
+	os.Setenv(envBaseURL, "https://from-jira.example.com")
+	os.Setenv(envLegacyBaseURL, "https://from-legacy.example.com")
 	os.Setenv("INPUT_TOKEN", "env-token")
 	os.Setenv("INPUT_REF", "ENV-1")
 	os.Setenv("INPUT_MARKDOWN", "false")

--- a/cmd/go-jira/config_test.go
+++ b/cmd/go-jira/config_test.go
@@ -433,14 +433,13 @@ func TestLoadConfig(t *testing.T) {
 // TestLoadConfig_InputPrefixStillWorks is a regression guard for the
 // GitHub Actions code path: when INPUT_* env vars are present (and no flags
 // are passed), loadConfig must still pick them up. INPUT_BASE_URL also remains
-// ahead of the local and legacy base-URL names; this is the path CI/CD relies
-// on.
+// ahead of JIRA_BASE_URL; the generic BASE_URL is intentionally ignored.
 func TestLoadConfig_InputPrefixStillWorks(t *testing.T) {
 	clearInputEnv(t)
 
 	os.Setenv(envInputBaseURL, "https://from-input.example.com")
 	os.Setenv(envBaseURL, "https://from-jira.example.com")
-	os.Setenv(envLegacyBaseURL, "https://from-legacy.example.com")
+	os.Setenv("BASE_URL", "https://unrelated.example.com")
 	os.Setenv("INPUT_TOKEN", "input-token")
 	os.Setenv("INPUT_REF", "ABC-1")
 	os.Setenv("INPUT_MARKDOWN", "true")
@@ -461,19 +460,19 @@ func TestLoadConfig_InputPrefixStillWorks(t *testing.T) {
 	}
 }
 
-// TestLoadConfig_BareEnvStillWorks confirms the legacy fallback path
-// (INPUT_* and JIRA_BASE_URL unset, only bare KEY env vars set) keeps working.
-func TestLoadConfig_BareEnvStillWorks(t *testing.T) {
+// TestLoadConfig_GenericBaseURLIsIgnored confirms only the URL field drops the
+// bare-name convention; unrelated existing bare action settings still work.
+func TestLoadConfig_GenericBaseURLIsIgnored(t *testing.T) {
 	clearInputEnv(t)
 
-	os.Setenv(envLegacyBaseURL, "https://from-bare.example.com")
+	os.Setenv("BASE_URL", "https://unrelated.example.com")
 	os.Setenv("TOKEN", "bare-token")
 	os.Setenv("REF", "ABC-2")
 
 	got := loadConfig(nil)
 
-	if got.baseURL != "https://from-bare.example.com" {
-		t.Errorf("baseURL = %q, want BASE_URL value", got.baseURL)
+	if got.baseURL != "" {
+		t.Errorf("baseURL = %q, want generic BASE_URL to be ignored", got.baseURL)
 	}
 	if got.token != "bare-token" {
 		t.Errorf("token = %q, want TOKEN value", got.token)
@@ -514,23 +513,63 @@ func TestLoadConfig_JiraAliasesWork(t *testing.T) {
 	}
 }
 
-// TestLoadConfig_JiraBaseURLBeatsLegacyBaseURL guards against collisions with
-// a generic BASE_URL set by another tool or loaded into the process first.
-func TestLoadConfig_JiraBaseURLBeatsLegacyBaseURL(t *testing.T) {
+// TestLoadConfig_JiraBaseURLIgnoresGenericBaseURL guards against collisions
+// with a generic BASE_URL set by another tool or loaded into the process first.
+func TestLoadConfig_JiraBaseURLIgnoresGenericBaseURL(t *testing.T) {
 	clearInputEnv(t)
 
-	os.Setenv(envLegacyBaseURL, "https://from-legacy.example.com")
+	os.Setenv("BASE_URL", "https://unrelated.example.com")
 	os.Setenv(envBaseURL, "https://from-jira.example.com")
 
 	got := loadConfig(nil)
 
 	if got.baseURL != "https://from-jira.example.com" {
-		t.Errorf("baseURL = %q, want JIRA_BASE_URL to win over legacy BASE_URL", got.baseURL)
+		t.Errorf("baseURL = %q, want JIRA_BASE_URL while generic BASE_URL is ignored", got.baseURL)
 	}
 }
 
+func TestBaseURLSourceIgnoresGenericBaseURL(t *testing.T) {
+	clearInputEnv(t)
+	os.Setenv("BASE_URL", "https://unrelated.example.com")
+
+	if got := baseURLSource(nil); got != sourceDefault {
+		t.Errorf("baseURLSource() = %q, want %q", got, sourceDefault)
+	}
+
+	os.Setenv(envBaseURL, "https://from-jira.example.com")
+	if got := baseURLSource(nil); got != sourceEnv {
+		t.Errorf("baseURLSource() = %q, want env", got)
+	}
+}
+
+func TestConfigShowIgnoresGenericBaseURL(t *testing.T) {
+	clearInputEnv(t)
+	t.Setenv("BASE_URL", "https://unrelated.example.com")
+
+	out := captureStderr(t, func() {
+		cmd := newConfigShowCmd()
+		if err := cmd.ParseFlags([]string{"--env-file="}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if err := runConfigShow(cmd); err != nil {
+			t.Fatalf("runConfigShow: %v", err)
+		}
+	})
+
+	for line := range strings.SplitSeq(out, "\n") {
+		cols := strings.Fields(line)
+		if len(cols) >= 3 && cols[0] == "base_url" {
+			if cols[1] != "(unset)" || cols[2] != sourceDefault {
+				t.Errorf("base_url row = %q, want (unset) %s", line, sourceDefault)
+			}
+			return
+		}
+	}
+	t.Fatalf("base_url row not found in config show output:\n%s", out)
+}
+
 // TestLoadConfig_BareTokenBeatsJiraAlias preserves the existing credential
-// precedence; only the base URL gives the JIRA_-prefixed name higher priority.
+// precedence for fields that still support both bare and JIRA_-prefixed names.
 func TestLoadConfig_BareTokenBeatsJiraAlias(t *testing.T) {
 	clearInputEnv(t)
 
@@ -552,7 +591,7 @@ func TestLoadConfig_FlagOverridesEnv(t *testing.T) {
 
 	os.Setenv("INPUT_BASE_URL", "https://from-env.example.com")
 	os.Setenv(envBaseURL, "https://from-jira.example.com")
-	os.Setenv(envLegacyBaseURL, "https://from-legacy.example.com")
+	os.Setenv("BASE_URL", "https://unrelated.example.com")
 	os.Setenv("INPUT_TOKEN", "env-token")
 	os.Setenv("INPUT_REF", "ENV-1")
 	os.Setenv("INPUT_MARKDOWN", "false")

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -119,16 +119,18 @@ const (
 	envBrokerTLSCert     = "JIRA_BROKER_TLS_CERT"
 	envBrokerTLSKey      = "JIRA_BROKER_TLS_KEY"
 
-	// JIRA_-prefixed aliases for the core auth/config fields, matching the env
-	// naming used throughout the docs and the auth-resolver error message. The
-	// action config still resolves these via the INPUT_<KEY>/<KEY> convention;
-	// these are additional fallbacks (lowest precedence) so the documented
-	// JIRA_* examples work as written.
-	envBaseURL  = "JIRA_BASE_URL"
-	envUsername = "JIRA_USERNAME"
-	envPassword = "JIRA_PASSWORD"
-	envToken    = "JIRA_TOKEN"
-	envInsecure = "JIRA_INSECURE"
+	// JIRA_-prefixed names for the core auth/config fields, matching the env
+	// naming used throughout the docs and the auth-resolver error message.
+	// The base URL has a dedicated precedence order so a generic BASE_URL from
+	// another tool cannot override the Jira-specific setting. INPUT_BASE_URL is
+	// retained for GitHub/Gitea Actions and BASE_URL as a legacy fallback.
+	envBaseURL       = "JIRA_BASE_URL"
+	envInputBaseURL  = "INPUT_BASE_URL"
+	envLegacyBaseURL = "BASE_URL"
+	envUsername      = "JIRA_USERNAME"
+	envPassword      = "JIRA_PASSWORD"
+	envToken         = "JIRA_TOKEN"
+	envInsecure      = "JIRA_INSECURE"
 )
 
 const (
@@ -368,7 +370,8 @@ func addEditableIssueFlags(cmd *cobra.Command) {
 // addCommonFlags registers flags shared by all subcommands that talk to Jira.
 func addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().String(flagEnvFile, ".env", "Read in a file of environment variables")
-	cmd.Flags().String(flagBaseURL, "", "Jira base URL (env: BASE_URL / INPUT_BASE_URL)")
+	cmd.Flags().String(flagBaseURL, "",
+		"Jira base URL (env: JIRA_BASE_URL; Actions: INPUT_BASE_URL)")
 	cmd.Flags().
 		Bool(flagInsecure, false, "Skip TLS verification (env: INSECURE / INPUT_INSECURE)")
 	cmd.Flags().Bool(flagDebug, false, "Dump resolved configuration (env: DEBUG / INPUT_DEBUG)")

--- a/cmd/go-jira/main.go
+++ b/cmd/go-jira/main.go
@@ -122,15 +122,14 @@ const (
 	// JIRA_-prefixed names for the core auth/config fields, matching the env
 	// naming used throughout the docs and the auth-resolver error message.
 	// The base URL has a dedicated precedence order so a generic BASE_URL from
-	// another tool cannot override the Jira-specific setting. INPUT_BASE_URL is
-	// retained for GitHub/Gitea Actions and BASE_URL as a legacy fallback.
-	envBaseURL       = "JIRA_BASE_URL"
-	envInputBaseURL  = "INPUT_BASE_URL"
-	envLegacyBaseURL = "BASE_URL"
-	envUsername      = "JIRA_USERNAME"
-	envPassword      = "JIRA_PASSWORD"
-	envToken         = "JIRA_TOKEN"
-	envInsecure      = "JIRA_INSECURE"
+	// another tool cannot affect Jira configuration. INPUT_BASE_URL is retained
+	// only for GitHub/Gitea Actions compatibility.
+	envBaseURL      = "JIRA_BASE_URL"
+	envInputBaseURL = "INPUT_BASE_URL"
+	envUsername     = "JIRA_USERNAME"
+	envPassword     = "JIRA_PASSWORD"
+	envToken        = "JIRA_TOKEN"
+	envInsecure     = "JIRA_INSECURE"
 )
 
 const (

--- a/cmd/go-jira/main_integration_test.go
+++ b/cmd/go-jira/main_integration_test.go
@@ -387,7 +387,7 @@ func TestRun(t *testing.T) {
 				"INPUT_BASE_URL", "INPUT_INSECURE", "INPUT_USERNAME", "INPUT_PASSWORD",
 				"INPUT_TOKEN", "INPUT_REF", "INPUT_ISSUE_FORMAT", "INPUT_TRANSITION",
 				"INPUT_RESOLUTION", "INPUT_COMMENT", "INPUT_ASSIGNEE", "INPUT_MARKDOWN",
-				"INPUT_DEBUG",
+				"INPUT_DEBUG", envBaseURL, envLegacyBaseURL,
 			}
 			for _, key := range envVars {
 				originalEnv[key] = os.Getenv(key)
@@ -403,7 +403,8 @@ func TestRun(t *testing.T) {
 				}
 			}()
 
-			// Setup test server only if BASE_URL is not explicitly tested to be missing
+			// Setup a test server unless INPUT_BASE_URL is explicitly testing the
+			// missing-value validation path.
 			if _, hasBaseURL := tt.envVars["INPUT_BASE_URL"]; !hasBaseURL {
 				server := setupTestServer(tt.serverOptions)
 				defer server.Close()
@@ -438,8 +439,15 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunWithEnvFile(t *testing.T) {
+	clearInputEnv(t)
+
+	// Setup test server before writing the env file so the file itself supplies
+	// the URL exercised by run.
+	server := setupTestServer(testServerOptions{})
+	defer server.Close()
+
 	// Create a temporary .env file
-	envContent := `INPUT_BASE_URL=https://jira.example.com
+	envContent := envBaseURL + "=" + server.URL + `
 INPUT_TOKEN=testtoken
 INPUT_REF=ABC-123
 `
@@ -456,17 +464,11 @@ INPUT_REF=ABC-123
 		t.Fatal(err)
 	}
 
-	// Setup test server
-	server := setupTestServer(testServerOptions{})
-	defer server.Close()
-
-	// Override base URL and insecure with test server
-	os.Setenv("INPUT_BASE_URL", server.URL)
+	// Simulate an unrelated process-level BASE_URL. The Jira-specific value
+	// loaded from the env file must win even though godotenv preserves existing
+	// process variables.
+	os.Setenv(envLegacyBaseURL, "not-a-valid-url")
 	os.Setenv("INPUT_INSECURE", "true")
-	defer func() {
-		os.Unsetenv("INPUT_BASE_URL")
-		os.Unsetenv("INPUT_INSECURE")
-	}()
 
 	// Run with env file via the --env-file flag on a fresh cobra command.
 	cmd := newRunCmd()

--- a/cmd/go-jira/main_integration_test.go
+++ b/cmd/go-jira/main_integration_test.go
@@ -387,7 +387,7 @@ func TestRun(t *testing.T) {
 				"INPUT_BASE_URL", "INPUT_INSECURE", "INPUT_USERNAME", "INPUT_PASSWORD",
 				"INPUT_TOKEN", "INPUT_REF", "INPUT_ISSUE_FORMAT", "INPUT_TRANSITION",
 				"INPUT_RESOLUTION", "INPUT_COMMENT", "INPUT_ASSIGNEE", "INPUT_MARKDOWN",
-				"INPUT_DEBUG", envBaseURL, envLegacyBaseURL,
+				"INPUT_DEBUG", envBaseURL, "BASE_URL",
 			}
 			for _, key := range envVars {
 				originalEnv[key] = os.Getenv(key)
@@ -467,7 +467,7 @@ INPUT_REF=ABC-123
 	// Simulate an unrelated process-level BASE_URL. The Jira-specific value
 	// loaded from the env file must win even though godotenv preserves existing
 	// process variables.
-	os.Setenv(envLegacyBaseURL, "not-a-valid-url")
+	os.Setenv("BASE_URL", "not-a-valid-url")
 	os.Setenv("INPUT_INSECURE", "true")
 
 	// Run with env file via the --env-file flag on a fresh cobra command.


### PR DESCRIPTION
## Summary

- Make `JIRA_BASE_URL` the only local and `.env` environment variable for the Jira instance URL.
- Resolve the base URL in this order: `--base-url` → `INPUT_BASE_URL` → `JIRA_BASE_URL`; the generic `BASE_URL` variable is intentionally ignored.
- Keep GitHub/Gitea Actions compatibility through `INPUT_BASE_URL` and report ignored generic values correctly in `config show`.
- Document the breaking migration in the changelog and the English, Traditional Chinese, and Simplified Chinese READMEs.
- Add unit and env-file integration coverage for resolution, source reporting, and environment collisions.

## Related issues

- Jira: N/A
- GitHub/Gitea: N/A

## Architecture / flow

```mermaid
flowchart TD
    A["resolveBaseURL"] --> B{"--base-url set?"}
    B -->|yes| R["Resolved Jira URL"]
    B -->|no| C{"INPUT_BASE_URL set?"}
    C -->|yes| R
    C -->|no| D{"JIRA_BASE_URL set?"}
    D -->|yes| R
    D -->|no| U["Unset"]

    style A fill:#d9eafd,stroke:#0969da
    style B fill:#fff8c5,stroke:#9a6700
    style C fill:#fff8c5,stroke:#9a6700
    style D fill:#d9eafd,stroke:#0969da
```

## AI authorship

- [ ] No AI was used
- [x] AI was used
  - **Tool / model**: OpenAI Codex / GPT-5
  - **AI-authored files**: `CHANGELOG.md`, `README.md`, `README.zh-cn.md`, `README.zh-tw.md`, `cmd/go-jira/config.go`, `cmd/go-jira/config_cmd.go`, `cmd/go-jira/config_test.go`, `cmd/go-jira/main.go`, `cmd/go-jira/main_integration_test.go`
  - **Human line-by-line reviewed**: The initial revision was confirmed by the author; the follow-up removal of `BASE_URL` support is pending final author review

## Change classification

- [ ] Leaf change
- [x] Core change

## Plan reference

Require a Jira-scoped base URL setting, eliminate collisions with generic application configuration, and provide an explicit migration path.

## Verification

- **Automated**: `go test ./... -count=1`; `go test -race ./cmd/go-jira -count=1`; `go vet ./...`; `golangci-lint run ./...` (0 issues); `git diff --staged --check`
- **Manual**: Confirmed `go-jira run --help` advertises `JIRA_BASE_URL` and `INPUT_BASE_URL`; verified the pushed branch matches local `HEAD`.
- **CI**: Re-triggered for commit `ca83257`; checks were pending when this description was updated.
- **Not run**: Stress/soak testing; the change is a synchronous environment lookup with unit and integration coverage.

## Security check

- [x] No secrets in the diff
- [x] External inputs are validated
- [x] Permission checks are tested — N/A; no permission behavior changed
- [x] Errors do not leak internals
- [ ] N/A - no external or security-sensitive interface changed

## Risk and rollback

- **Risk**: Users relying only on `BASE_URL` will now receive the existing missing-base-URL validation error and must migrate to `JIRA_BASE_URL`, `INPUT_BASE_URL`, or `--base-url`.
- **Rollback**: Revert commit `ca83257` to restore the legacy fallback while retaining the Jira-specific precedence change.

## Reviewer guide

- **Read carefully**: `resolveBaseURL`, `baseURLSource`, the precedence/source tests, and the changelog migration note.
- **Spot-check**: CLI help text and the three README translations.
